### PR TITLE
NEW: Refactor document generators to use shared EasyDocHtmlTrait

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,41 +1,41 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CHANGELOG
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  release:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Bump version')"
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
-         fetch-depth: '0'
+          fetch-depth: '0'
+
       - name: Setup PHP
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
           tools: php-parallel-lint/php-var-dump-check, parallel-lint, cs2pr, phpcs
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 14.x
-      #     registry-url: 'https://registry.npmjs.org'
-      - name: Print PHP version
-        run: echo ${{ steps.setup-php.outputs.php-version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Run PHPCS
+        run: phpcs -q --report=checkstyle --standard=codesniffer/ruleset.xml --extensions=php --ignore=*/tx/*,*/vendor/* . | cs2pr --graceful-warnings
+
+      - name: Run Parallel Lint
+        run: parallel-lint --exclude vendor/ .
+
+      - name: Run VarDump Check
+        run: var-dump-check --extensions php --tracy --exclude vendor/ .
+
       - name: Run autotranslator
         run: |
           php ./.tx/autotranslator.php fr_FR it_IT ${{ secrets.GOOGLE_API_TRANSLATE }}
@@ -44,10 +44,12 @@ jobs:
           php ./.tx/autotranslator.php fr_FR de_DE ${{ secrets.GOOGLE_API_TRANSLATE }}
           php ./.tx/autotranslator.php fr_FR pt_PT ${{ secrets.GOOGLE_API_TRANSLATE }}
           php ./.tx/autotranslator.php fr_FR pl_PL ${{ secrets.GOOGLE_API_TRANSLATE }}
+
       - name: Run changelog
         run: npx lerna-changelog --from=v0.0.0 > ChangeLog.md
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Bump version and push tag
         uses: frederic34/github-dolibarr-action@main
         env:
@@ -60,17 +62,19 @@ jobs:
           DEFAULT_BUMP: none
           INITIAL_VERSION: v0.0.0
           VERBOSE: true
+
       - name: Zip Folder
         run: |
           composer update --no-dev
-          ls -al
-          mkdir build/easydocgenerator
+          mkdir -p build/easydocgenerator
           rsync -arv --exclude='.git/' --exclude='.github/' --exclude='.gitignore' --exclude='.tx/' --exclude='build/' --exclude='codesniffer/' . ./build/easydocgenerator
-      - name: Switch to Release Folder
+
+      - name: Create release zip
         run: |
           cd build
-          rm module_easydocgenerator-${{ env.module_version }}.zip 2> /dev/null || true
+          rm -f module_easydocgenerator-${{ env.module_version }}.zip
           zip -r module_easydocgenerator-${{ env.module_version }}.zip easydocgenerator
-      - uses: stefanzweifel/git-auto-commit-action@v4
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Bump version #none

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,61 +1,36 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  lint:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
-         fetch-depth: '0'
+          fetch-depth: '0'
+
       - name: Setup PHP
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.2'
           tools: php-parallel-lint/php-var-dump-check, parallel-lint, cs2pr, phpcs
-      # - uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 14.x
-      #     registry-url: 'https://registry.npmjs.org'
+
       - name: Print PHP version
         run: echo ${{ steps.setup-php.outputs.php-version }}
+
       - name: Run PHPCS
         run: phpcs -q --report=checkstyle --standard=codesniffer/ruleset.xml --extensions=php --ignore=*/tx/*,*/vendor/* . | cs2pr --graceful-warnings
+
       - name: Run Parallel Lint
         run: parallel-lint --exclude vendor/ .
+
       - name: Run VarDump Check
         run: var-dump-check --extensions php --tracy --exclude vendor/ .
-      - name: Bump version and push tag
-        uses: frederic34/github-dolibarr-action@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: frederic34
-          RELEASE_BRANCH: main
-          MODULE: easydocgenerator
-          CLASSNAME: Easydocgenerator
-          RELEASE_BRANCHES: main
-          DEFAULT_BUMP: none
-          INITIAL_VERSION: v0.0.0
-          VERBOSE: true
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Bump version #none

--- a/class/EasyDocHtmlTrait.php
+++ b/class/EasyDocHtmlTrait.php
@@ -1,0 +1,474 @@
+<?php
+/* Copyright (C) 2018-2024  Frédéric France     <frederic.france@free.fr>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    class/EasyDocHtmlTrait.php
+ * \ingroup easydocgenerator
+ * \brief   Shared logic for all EasyDoc HTML/PDF document generators
+ *
+ * Each using class must set in its constructor:
+ *   $this->scandir            — constant name for template path (e.g. 'INVOICE_ADDON_EASYDOC_TEMPLATES_PATH')
+ *   $this->templateFileSection — URL section for document.php file listing (e.g. 'invoices')
+ */
+
+use NumberToWords\NumberToWords;
+
+/**
+ * Trait EasyDocHtmlTrait
+ */
+trait EasyDocHtmlTrait
+{
+	/**
+	 * Return description of a module (admin settings page).
+	 * Uses $this->scandir and $this->templateFileSection set by the constructor.
+	 *
+	 * @param Translate $langs Lang object
+	 * @return string          HTML content
+	 */
+	public function info($langs)
+	{
+		global $conf, $langs;
+
+		$langs->loadLangs(['errors', 'companies', 'easydocgenerator@easydocgenerator']);
+
+		$form = new Form($this->db);
+
+		$text = $this->description . ".<br>\n";
+		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
+		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
+		$text .= '<input type="hidden" name="page_y" value="">';
+		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
+		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
+		$text .= '<table class="nobordernopadding" width="100%">';
+		$text .= '<tr><td>';
+		$texttitle = $langs->trans('ListOfDirectoriesForHtmlTemplates');
+		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
+		$listoffiles = [];
+		foreach ($listofdir as $key => $tmpdir) {
+			$tmpdir = trim($tmpdir);
+			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
+			if (!$tmpdir) {
+				unset($listofdir[$key]);
+				continue;
+			}
+			if (!is_dir($tmpdir)) {
+				$texttitle .= img_warning($langs->trans('ErrorDirNotFound', $tmpdir), 0);
+			} else {
+				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
+				if (count($tmpfiles)) {
+					$listoffiles = array_merge($listoffiles, $tmpfiles);
+				}
+			}
+		}
+		$texthelp = $langs->trans('ListOfDirectoriesForModelGenHTML');
+		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans('ExampleOfDirectoriesForModelGen') . '</span>';
+		$texthelp .= '<br>' . $langs->trans('FollowingSubstitutionKeysCanBeUsed') . '<br>';
+		$texthelp .= $langs->transnoentitiesnoconv('FullListOnOnlineDocumentation');
+
+		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
+		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
+		$text .= '<textarea class="flat" cols="60" name="value1">';
+		$text .= getDolGlobalString($this->scandir);
+		$text .= '</textarea>';
+		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
+		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans('Modify')) . '">';
+		$text .= '<br></div></div>';
+
+		$nbofiles = count($listoffiles);
+		if (getDolGlobalString($this->scandir)) {
+			$text .= $langs->trans('NumberOfModelHTMLFilesFound') . ': <b>';
+			$text .= count($listoffiles);
+			$text .= '</b>';
+		}
+
+		if ($nbofiles) {
+			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
+			foreach ($listoffiles as $file) {
+				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=' . $this->templateFileSection . '/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
+				$url = $_SERVER['PHP_SELF'] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name']));
+				$text .= ' &nbsp; <a class="reposition" href="' . $url . '">' . img_picto('', 'delete') . '</a>';
+				$text .= '<br>';
+			}
+			$text .= '</div>';
+		}
+		$text .= '<div>' . $langs->trans('UploadNewTemplate');
+		$maxfilesizearray = getMaxFileSizeArray();
+		$maxmin = $maxfilesizearray['maxmin'];
+		if ($maxmin > 0) {
+			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
+		}
+		$text .= ' <input type="file" name="uploadfile">';
+		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
+		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans('Upload')) . '" name="upload">';
+		$text .= '</div>';
+		$text .= '</td></tr></table></form>';
+
+		return $text;
+	}
+
+	/**
+	 * Build and return a configured Twig environment for the given template.
+	 *
+	 * @param string $srctemplatepath Full path to the .twig template file
+	 * @return \Twig\Environment
+	 */
+	protected function buildTwigEnvironment(string $srctemplatepath): \Twig\Environment
+	{
+		require_once dol_buildpath('easydocgenerator/vendor/autoload.php');
+		$md5id = md5_file($srctemplatepath);
+		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
+		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
+		$twig = new \Twig\Environment($loader, [
+			'cache' => $enablecache,
+			'autoescape' => false,
+		]);
+
+		$twig->addFunction(new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
+			global $outputlangs, $langs;
+			if (!is_object($outputlangs)) {
+				$outputlangs = $langs;
+				$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator']);
+			}
+			return $outputlangs->trans($value, $param1, $param2, $param3);
+		}));
+
+		$twig->addFunction(new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
+			global $outputlangsbis, $langs;
+			if (!is_object($outputlangsbis)) {
+				$outputlangsbis = $langs;
+				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator']);
+			}
+			return $outputlangsbis->trans($value, $param1, $param2, $param3);
+		}));
+
+		$twig->addFunction(new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
+			return getDolGlobalString($value, $default);
+		}));
+
+		$twig->addFunction(new \Twig\TwigFunction('date', function ($time, $format = '') {
+			return dol_print_date($time, $format);
+		}));
+
+		$twig->addFunction(new \Twig\TwigFunction('price', function ($price) {
+			global $outputlangs, $langs;
+			return price($price, 0, $outputlangs);
+		}));
+
+		$twig->addFunction(new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
+			$numbertow = new NumberToWords();
+			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
+			return $currencyTransformer->toWords($number * 100, $currency);
+		}));
+
+		return $twig;
+	}
+
+	/**
+	 * Compute the logo path.
+	 *
+	 * @return string
+	 */
+	protected function buildLogo(): string
+	{
+		global $conf;
+		$logo = '';
+		if (!empty($this->emetteur->logo)) {
+			$logodir = $conf->mycompany->dir_output;
+			$logo = getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')
+				? $logodir . '/logos/' . $this->emetteur->logo
+				: $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
+		}
+		return $logo;
+	}
+
+	/**
+	 * Compute the mysoc flag image code.
+	 *
+	 * @return string
+	 */
+	protected function buildFlagImage(): string
+	{
+		global $mysoc;
+		$langtocountryflag = [
+			'ar_AR' => '',
+			'ca_ES' => 'catalonia',
+			'da_DA' => 'dk',
+			'fr_CA' => 'mq',
+			'sv_SV' => 'se',
+			'sw_SW' => 'unknown',
+			'AQ' => 'unknown',
+			'CW' => 'unknown',
+			'IM' => 'unknown',
+			'JE' => 'unknown',
+			'MF' => 'unknown',
+			'BL' => 'unknown',
+			'SX' => 'unknown',
+		];
+		if (isset($langtocountryflag[$mysoc->country_code])) {
+			return $langtocountryflag[$mysoc->country_code];
+		}
+		$tmparray = explode('_', $mysoc->country_code);
+		return empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
+	}
+
+	/**
+	 * Build mysoc substitutions.
+	 *
+	 * @param Translate $outputlangs
+	 * @param string    $flagImage
+	 * @return array
+	 */
+	protected function buildMysocSubstitutions($outputlangs, string $flagImage): array
+	{
+		global $mysoc;
+		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
+		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
+		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
+		$substitutions['mysoc']['phone_mobile_formatted'] = dol_print_phone($mysoc->phone_mobile ?? '', $mysoc->country_code, 0, 0, '', ' ');
+		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
+		return $substitutions;
+	}
+
+	/**
+	 * Build thirdparty substitutions (only when $object->thirdparty is set).
+	 *
+	 * @param CommonObject $object
+	 * @param Translate    $outputlangs
+	 * @return array
+	 */
+	protected function buildThirdpartySubstitutions($object, $outputlangs): array
+	{
+		if (empty($object->thirdparty) || !is_object($object->thirdparty)) {
+			return [];
+		}
+		$substitutions = getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty');
+		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
+		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		return $substitutions;
+	}
+
+	/**
+	 * Build contacts substitutions with photo resolution (invoice/order/expedition/propale).
+	 *
+	 * Produces $contacts['{type}_{scope}'][$contactId] = [...fields...].
+	 *
+	 * @param CommonObject $object
+	 * @param Translate    $outputlangs
+	 * @param array        $typescontact ['external' => [...], 'internal' => [...]]
+	 * @return array
+	 */
+	protected function buildContactsSubstitutions($object, $outputlangs, array $typescontact): array
+	{
+		global $conf;
+		$contacts = [];
+		foreach ($typescontact as $key => $value) {
+			foreach ($value as $type) {
+				$arrayidcontact = $object->getIdContact($key, $type);
+				foreach ($arrayidcontact as $idc) {
+					$contact = ($key === 'external') ? new Contact($this->db) : new User($this->db);
+					$res = $contact->fetch($idc);
+					if ($res < 0) {
+						setEventMessages($contact->error, $contact->errors, 'errors');
+					} else {
+						$contacts[strtolower($type) . '_' . $key][$idc] = getEachVarObject($contact, $outputlangs, 0, $idc)[$idc];
+					}
+				}
+				if (!empty($contacts[strtolower($type) . '_' . $key])) {
+					foreach ($contacts[strtolower($type) . '_' . $key] as $jdx => $substitution) {
+						if (!empty($substitution['photo'])) {
+							$contacts[strtolower($type) . '_' . $key][$jdx]['picture'] = $conf->{$substitution['element']}->multidir_output[$conf->entity] . '/' . $substitution['id'] . '/photos/' . $substitution['photo'];
+						}
+					}
+				}
+			}
+		}
+		return $contacts;
+	}
+
+	/**
+	 * Build contacts substitutions, simple version (contract/stock/ticket).
+	 *
+	 * Produces $substitutions['{type}_{scope}'][0..n] = [...fields...].
+	 *
+	 * @param CommonObject $object
+	 * @param Translate    $outputlangs
+	 * @param array        $typescontact ['external' => [...], 'internal' => [...]]
+	 * @return array
+	 */
+	protected function buildContactsSubstitutionsSimple($object, $outputlangs, array $typescontact): array
+	{
+		$substitutions = [];
+		foreach ($typescontact as $key => $value) {
+			foreach ($value as $type) {
+				$arrayidcontact = $object->getIdContact($key, $type);
+				$contacts = [];
+				foreach ($arrayidcontact as $idc) {
+					$contact = ($key === 'external') ? new Contact($this->db) : new User($this->db);
+					$contact->fetch($idc);
+					$contacts[] = $contact;
+				}
+				$substitutions = array_merge($substitutions, getEachVarObject($contacts, $outputlangs, 1, strtolower($type) . '_' . $key));
+			}
+		}
+		return $substitutions;
+	}
+
+	/**
+	 * Build lines substitutions from $object->lines (standard, no photos/categories).
+	 *
+	 * @param CommonObject $object
+	 * @param Translate    $outputlangs
+	 * @param bool         $fetchProduct Fetch and embed product data for each line
+	 * @return array
+	 */
+	protected function buildLinesSubstitutions($object, $outputlangs, bool $fetchProduct = false): array
+	{
+		$subtotal_ht = 0;
+		$subtotal_ttc = 0;
+		$linenumber = 1;
+		$linesarray = [];
+		foreach ($object->lines as $key => $line) {
+			$subtotal_ht += $line->total_ht;
+			$subtotal_ttc += $line->total_ttc;
+			if ($line->special_code == 104777 && $line->qty == 99) {
+				$line->total_ht = $subtotal_ht;
+				$line->total_ttc = $subtotal_ttc;
+				$subtotal_ht = 0;
+				$subtotal_ttc = 0;
+			}
+			$linearray = getEachVarObject($line, $outputlangs, 1, 'line');
+			$linesarray[$key] = $linearray['line'];
+			$linesarray[$key]['linenumber'] = $linenumber;
+			$linesarray[$key]['subtotal_ht'] = $subtotal_ht;
+			if ($fetchProduct && $line->fk_product > 0) {
+				$product = new Product($this->db);
+				$product->fetch($line->fk_product);
+				$linesarray[$key]['product'] = getEachVarObject($product, $outputlangs)['object'];
+			}
+			if (empty($line->special_code)) {
+				$linenumber++;
+			}
+		}
+		return $linesarray;
+	}
+
+	/**
+	 * Build lines substitutions with product photos and categories (expedition/propale).
+	 *
+	 * @param CommonObject $object
+	 * @param Translate    $outputlangs
+	 * @param bool         $recursive Passed to getEachVarObject for line fields (true=expedition, false=propale)
+	 * @return array
+	 */
+	protected function buildExtendedLinesSubstitutions($object, $outputlangs, bool $recursive = true): array
+	{
+		global $conf;
+		$subtotal_ht = 0;
+		$subtotal_ttc = 0;
+		$linenumber = 1;
+		$linesarray = [];
+		foreach ($object->lines as $key => $line) {
+			$subtotal_ht += $line->total_ht;
+			$subtotal_ttc += $line->total_ttc;
+			if ($line->special_code == 104777 && $line->qty == 99) {
+				$line->total_ht = $subtotal_ht;
+				$line->total_ttc = $subtotal_ttc;
+				$subtotal_ht = 0;
+				$subtotal_ttc = 0;
+			}
+			$linearray = getEachVarObject($line, $outputlangs, (int) $recursive, 'line');
+			$linesarray[$key] = $linearray['line'];
+			$linesarray[$key]['linenumber'] = $linenumber;
+			$linesarray[$key]['subtotal_ht'] = $subtotal_ht;
+			if ($line->fk_product > 0) {
+				$product = new Product($this->db);
+				$product->fetch($line->fk_product);
+				$linesarray[$key]['product'] = getEachVarObject($product, $outputlangs)['object'];
+				$cat = new Categorie($this->db);
+				$linesarray[$key]['categories'] = $cat->getListForItem($line->fk_product, 'product');
+				$linesarray[$key]['photos'] = [];
+				$pdir = [];
+				if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
+					$pdir[0] = get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . '/photos/';
+					$pdir[1] = get_exdir(0, 0, 0, 0, $product, 'product') . dol_sanitizeFileName($product->ref) . '/';
+				} else {
+					$pdir[0] = get_exdir(0, 0, 0, 0, $product, 'product');
+					$pdir[1] = get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . '/photos/';
+				}
+				foreach ($pdir as $midir) {
+					$dir = ($conf->entity != $product->entity)
+						? $conf->product->multidir_output[$product->entity] . '/' . $midir
+						: $conf->product->dir_output . '/' . $midir;
+					foreach ($product->liste_photos($dir, 1) as $obj) {
+						$linesarray[$key]['photos'][] = $dir . $obj['photo'];
+					}
+				}
+			}
+			if (empty($line->special_code)) {
+				$linenumber++;
+			}
+		}
+		return $linesarray;
+	}
+
+	/**
+	 * Save the PDF to disk, fire afterPDFCreation hook, set $this->result.
+	 *
+	 * The caller must have already called $mpdf->WriteHTML($html) before calling this method.
+	 *
+	 * @param \Mpdf\Mpdf   $mpdf
+	 * @param CommonObject $object
+	 * @param Translate    $outputlangs
+	 * @param string       $dir             Base output directory (e.g. $conf->facture->multidir_output[$entity])
+	 * @param string       $srctemplatepath Full path to the .twig source template
+	 * @return int 1 on success, -1 on error
+	 */
+	protected function savePdf(\Mpdf\Mpdf $mpdf, $object, $outputlangs, string $dir, string $srctemplatepath): int
+	{
+		global $action, $langs, $hookmanager, $outputlangsbis;
+
+		$objectref = dol_sanitizeFileName($object->ref);
+		if (!preg_match('/specimen/i', $objectref)) {
+			$dir .= '/' . $objectref;
+		}
+		$filename = str_replace('.twig', '', basename($srctemplatepath));
+		$file = getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')
+			? $dir . '/' . $objectref . '_' . $filename . '.pdf'
+			: $dir . '/' . $objectref . '.pdf';
+
+		if (!file_exists($dir)) {
+			if (dol_mkdir($dir) < 0) {
+				$this->error = $langs->transnoentities('ErrorCanNotCreateDir', $dir);
+				return -1;
+			}
+		}
+
+		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
+
+		$parameters = [
+			'file' => $file,
+			'object' => $object,
+			'outputlangs' => $outputlangs,
+			'outputlangsbis' => $outputlangsbis,
+		];
+		$hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
+
+		$this->result = ['fullpath' => $file];
+		return 1;
+	}
+}

--- a/core/modules/bom/doc/doc_easydoc_bom_html.modules.php
+++ b/core/modules/bom/doc/doc_easydoc_bom_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for boms
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/bom/modules_bom.php';
 require_once DOL_DOCUMENT_ROOT . '/bom/class/bom.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
@@ -37,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -45,34 +44,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_bom_html extends ModelePDFbom
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
-		$langs->loadLangs(["main", "companies", "easydocgenerator@easydocgenerator"]);
+		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'BOM_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'bom';
 		$this->update_main_doc_field = ((int) DOL_VERSION < 21) ? 0 : 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -82,125 +74,20 @@ class doc_easydoc_bom_html extends ModelePDFbom
 		$this->marge_haute = getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48);
 		$this->marge_basse = getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 48);
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $conf, $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		// $texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		// $texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=products/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$url = $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name']));
-				$text .= ' &nbsp; <a class="reposition" href="' . $url . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -221,7 +108,7 @@ class doc_easydoc_bom_html extends ModelePDFbom
 		global $action, $langs, $conf, $mysoc, $hookmanager, $user;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_product_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_bom_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -243,86 +130,23 @@ class doc_easydoc_bom_html extends ModelePDFbom
 			$outputlangsbis->loadLangs($langfiles);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'mrp', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'mrp', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			global $outputlangs, $langs;
-			return price($price, 0, $outputlangs);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -332,127 +156,31 @@ class doc_easydoc_bom_html extends ModelePDFbom
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
 
-		// Recipient name
-		$contactobject = null;
-		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
-				$object->contact->fetch_thirdparty();
-				$socobject = $object->contact->thirdparty;
-				$contactobject = $object->contact;
-			} else {
-				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
-				$contactobject = $object->contact;
-			}
-		} else {
-			$socobject = $object->thirdparty;
-		}
-
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis, 'substitutionarray' => &$substitutionarray];
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Call the ODTSubstitution hook
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-			'substitutionarray' => &$substitutionarray,
-		];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
-
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'BOM_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
-		// if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
-		// 	$pdir[0] = get_exdir($object->id, 2, 0, 0, $object, 'product') . $object->id . "/photos/";
-		// 	$pdir[1] = get_exdir(0, 0, 0, 0, $object, 'product') . dol_sanitizeFileName($object->ref) . '/';
-		// } else {
-		// 	$pdir[0] = get_exdir(0, 0, 0, 0, $object, 'product'); // default
-		// 	$pdir[1] = get_exdir($object->id, 2, 0, 0, $object, 'product') . $object->id . "/photos/"; // alternative
-		// }
-		// $pictures = [];
-		// foreach ($pdir as $midir) {
-		// 	if ($conf->entity != $object->entity) {
-		// 		$dir = $conf->product->multidir_output[$object->entity] . '/' . $midir; //Check repertories of current entities
-		// 	} else {
-		// 		$dir = $conf->product->dir_output . '/' . $midir; //Check repertory of the current product
-		// 	}
-		// 	foreach ($object->liste_photos($dir) as $key => $obj) {
-		// 		$exif = '';
-		// 		if (function_exists('exif_read_data')) {
-		// 			$exif = exif_read_data($dir . $obj['photo']);
-		// 		}
-		// 		if ($obj['photo_vignette']) {
-		// 			$pictures[] = [
-		// 				'dir' => $dir,
-		// 				'thumb' => $obj['photo_vignette'],
-		// 				'original' => $obj['photo'],
-		// 				'exif' => $exif,
-		// 			];
-		// 		} else {
-		// 			$pictures[] = [
-		// 				'dir' => $dir,
-		// 				'original' => $obj['photo'],
-		// 				'exif' => $exif,
-		// 			];
-		// 		}
-		// 	}
-		// }
-		// $substitutions = array_merge($substitutions, ['pictures' => $pictures]);
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
@@ -460,46 +188,14 @@ class doc_easydoc_bom_html extends ModelePDFbom
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		// foreach ($object->lines as $key => $line) {
-		// 	$subtotal_ht += $line->total_ht;
-		// 	$subtotal_ttc += $line->total_ttc;
-		// 	if ($line->special_code == 104777 && $line->qty == 99) {
-		// 		$line->total_ht = $subtotal_ht;
-		// 		$line->total_ttc = $subtotal_ttc;
-		// 		$subtotal_ht = 0;
-		// 		$subtotal_ttc = 0;
-		// 	}
-		// 	$substitutions['lines'][$key] = [
-		// 		'linenumber' => $linenumber,
-		// 		'qty' => $line->qty,
-		// 		'ref' => $line->product_ref,
-		// 		'label' => $line->label,
-		// 		'description' => $line->desc,
-		// 		'product_label' => $line->product_label,
-		// 		'product_description' => $line->product_desc,
-		// 		'subprice' => price($line->subprice),
-		// 		'total_ht' => price($line->total_ht),
-		// 		'total_ttc' => price($line->total_ttc),
-		// 		'vatrate' => price($line->tva_tx) . '%',
-		// 		'special_code' => $line->special_code,
-		// 		'product_type' => $line->product_type,
-		// 		'line_options' => [],
-		// 		'product_options' => [],
-		// 	];
-		// 	if (empty($line->special_code)) {
-		// 		$linenumber++;
-		// 	}
-		// }
 
-		// var_dump($substitutions);
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -509,7 +205,7 @@ class doc_easydoc_bom_html extends ModelePDFbom
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -517,15 +213,14 @@ class doc_easydoc_bom_html extends ModelePDFbom
 			'margin_right' => $this->marge_droite,
 			'margin_top' => $this->marge_haute,
 			'margin_bottom' => $this->marge_basse,
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
-		$mpdf->SetTitle($outputlangs->convToOutputCharset("Product"));
+		$mpdf->SetTitle($outputlangs->convToOutputCharset('Product'));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("Product"));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('Product'));
 		$text = getDolGlobalString('BOM_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -534,44 +229,10 @@ class doc_easydoc_bom_html extends ModelePDFbom
 		$mpdf->showWatermarkText = (!$object->status_buy && getDolGlobalString('BOM_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfProductTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->bom->multidir_output[isset($object->entity) ? $object->entity : 1];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$parameters = [
-			'file' => $file,
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		// Note that $action and $object may have been modified by some hooks
-		$hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->bom->multidir_output[isset($object->entity) ? $object->entity : 1], $srctemplatepath);
 	}
 }

--- a/core/modules/commande/doc/doc_easydoc_order_html.modules.php
+++ b/core/modules/commande/doc/doc_easydoc_order_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for orders
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/commande/modules_commande.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
@@ -38,6 +36,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -46,34 +45,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_order_html extends ModelePDFCommandes
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'ORDER_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'orders';
 		$this->update_main_doc_field = 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -83,125 +75,20 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $conf, $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		$texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		$texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=orders/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$url = $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name']));
-				$text .= ' &nbsp; <a class="reposition" href="' . $url . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -222,7 +109,7 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 		global $action, $langs, $conf, $mysoc, $hookmanager, $user;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_order_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_order_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -242,86 +129,24 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 			$outputlangsbis->loadLangs($langfiles);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
 		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			global $outputlangs, $langs;
-			return price($price, 0, $outputlangs);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -331,207 +156,84 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
+
 		$label_payment_conditions = '';
 		if ($object->cond_reglement_code) {
-			$label_payment_conditions = ($outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
+			$label_payment_conditions = ($outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
 			$label_payment_conditions = str_replace('\n', "\n", $label_payment_conditions);
 			if ($object->deposit_percent > 0) {
 				$label_payment_conditions = str_replace('__DEPOSIT_PERCENT__', $object->deposit_percent, $label_payment_conditions);
 			}
 		}
-		// If CUSTOMER contact defined on order, we use it
+
 		$usecontact = false;
 		$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
 		if (count($arrayidcontact) > 0) {
 			$usecontact = true;
 			$result = $object->fetch_contact($arrayidcontact[0]);
 		}
-
-		// Recipient name
 		$contactobject = null;
 		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
 			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
 				$object->contact->fetch_thirdparty();
 				$socobject = $object->contact->thirdparty;
 				$contactobject = $object->contact;
 			} else {
 				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
 				$contactobject = $object->contact;
 			}
 		} else {
 			$socobject = $object->thirdparty;
 		}
 
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
-
-		// Call the ODTSubstitution hook
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-			'substitutionarray' => &$substitutionarray,
-		];
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis, 'substitutionarray' => &$substitutionarray];
 		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'ORDER_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
-
-		// thirdparty
-		$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
 		];
-		$contacts = [];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $idx => $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$res = $contact->fetch($idc);
-					if ($res < 0) {
-						setEventMessages($contact->error, $contact->errors, 'errors');
-					} else {
-						$contacts[strtolower($type) . '_' . $key][$idc] = getEachVarObject($contact, $outputlangs, 0, $idc)[$idc];
-					}
-				}
-				if (!empty($contacts[strtolower($type) . '_' . $key])) {
-					foreach ($contacts[strtolower($type) . '_' . $key] as $jdx => $substitution) {
-						if (!empty($substitution['photo'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['picture'] = $conf->{$substitution['element']}->multidir_output[$conf->entity] . '/' . $substitution['id'] . '/photos/' . $substitution['photo'];
-						}
-					}
-				}
-			}
-		}
-		$substitutions = array_merge($substitutions, $contacts);
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutions($object, $outputlangs, $typescontact));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
-			'lines' => [],
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'labelpaymentconditions' => $label_payment_conditions,
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		$linesarray = [];
-		foreach ($object->lines as $key => $line) {
-			$subtotal_ht += $line->total_ht;
-			$subtotal_ttc += $line->total_ttc;
-			if ($line->special_code == 104777 && $line->qty == 99) {
-				$line->total_ht = $subtotal_ht;
-				$line->total_ttc = $subtotal_ttc;
-				$subtotal_ht = 0;
-				$subtotal_ttc = 0;
-			}
-			$linearray = getEachVarObject($line, $outputlangs, 1, 'line');
-			$linesarray[$key] = $linearray['line'];
-			$linesarray[$key]['linenumber'] = $linenumber;
-			$linesarray[$key]['subtotal_ht'] = $subtotal_ht;
-			// $substitutions['lines'][$key] = [
-			// 	'linenumber' => $linenumber,
-			// 	'qty' => $line->qty,
-			// 	'ref' => $line->product_ref,
-			// 	'label' => $line->label,
-			// 	'description' => $line->desc,
-			// 	'product_label' => $line->product_label,
-			// 	'product_description' => $line->product_desc,
-			// 	'subprice' => $line->subprice,
-			// 	'total_ht' => $line->total_ht,
-			// 	'total_ttc' => $line->total_ttc,
-			// 	'vatrate' => $line->tva_tx,
-			// 	'special_code' => $line->special_code,
-			// 	'product_type' => $line->product_type,
-			// 	'line_options' => [],
-			// 	'product_options' => [],
-			// ];
-			if (empty($line->special_code)) {
-				$linenumber++;
-			}
-		}
-		$substitutions = array_merge($substitutions, ['lines' => $linesarray]);
 
+		$substitutions = array_merge($substitutions, ['lines' => $this->buildLinesSubstitutions($object, $outputlangs)]);
+
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -541,7 +243,7 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -549,15 +251,14 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("PdfOrderTitle") . " " . $outputlangs->convToOutputCharset($object->thirdparty->name));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('PdfOrderTitle') . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name));
 		$text = getDolGlobalString('COMMANDE_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -566,44 +267,10 @@ class doc_easydoc_order_html extends ModelePDFCommandes
 		$mpdf->showWatermarkText = ($object->statut == Commande::STATUS_DRAFT && getDolGlobalString('COMMANDE_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfOrderTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->commande->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$parameters = [
-			'file' => $file,
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		// Note that $action and $object may have been modified by some hooks
-		$hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->commande->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/contract/doc/doc_easydoc_contract_html.modules.php
+++ b/core/modules/contract/doc/doc_easydoc_contract_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for contracts
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/contract/modules_contract.php';
 require_once DOL_DOCUMENT_ROOT . '/contrat/class/contrat.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
@@ -37,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -45,34 +44,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_contract_html extends ModelePDFContract
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'CONTRACT_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'contracts';
 		$this->update_main_doc_field = 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -82,125 +74,20 @@ class doc_easydoc_contract_html extends ModelePDFContract
 		$this->marge_haute = getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48);
 		$this->marge_basse = getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 48);
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $conf, $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		$texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		$texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=contracts/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$url = $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name']));
-				$text .= ' &nbsp; <a class="reposition" href="' . $url . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -221,7 +108,7 @@ class doc_easydoc_contract_html extends ModelePDFContract
 		global $action, $langs, $conf, $mysoc, $hookmanager, $user;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_contract_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_contract_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -241,84 +128,23 @@ class doc_easydoc_contract_html extends ModelePDFContract
 			$outputlangsbis->loadLangs($langfiles);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			global $outputlangs, $langs;
-			return price($price, 0, $outputlangs);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -328,183 +154,54 @@ class doc_easydoc_contract_html extends ModelePDFContract
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
-		// If CUSTOMER contact defined on contract, we use it
-		$usecontact = false;
-		$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
-		if (count($arrayidcontact) > 0) {
-			$usecontact = true;
-			$result = $object->fetch_contact($arrayidcontact[0]);
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
 
-		// Recipient name
-		$contactobject = null;
-		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
-				$object->contact->fetch_thirdparty();
-				$socobject = $object->contact->thirdparty;
-				$contactobject = $object->contact;
-			} else {
-				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
-				$contactobject = $object->contact;
-			}
-		} else {
-			$socobject = $object->thirdparty;
-		}
-
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis, 'substitutionarray' => &$substitutionarray];
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Call the ODTSubstitution hook
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-			'substitutionarray' => &$substitutionarray,
-		];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
-
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'CONTRACT_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
-
-		// thirdparty
-		$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
 		];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				$contacts = [];
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$contact->fetch($idc);
-					$contacts[] = $contact;
-				}
-				$substitutions = array_merge($substitutions, getEachVarObject($contacts, $outputlangs, 1, strtolower($type) . '_' . $key));
-			}
-		}
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutionsSimple($object, $outputlangs, $typescontact));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
-			'lines' => [],
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		// var_dump($substitutions);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		foreach ($object->lines as $key => $line) {
-			$subtotal_ht += $line->total_ht;
-			$subtotal_ttc += $line->total_ttc;
-			if ($line->special_code == 104777 && $line->qty == 99) {
-				$line->total_ht = $subtotal_ht;
-				$line->total_ttc = $subtotal_ttc;
-				$subtotal_ht = 0;
-				$subtotal_ttc = 0;
-			}
-			$vars = getEachVarObject($line, $outputlangs, 1, 'line');
-			$substitutions['lines'][$key] = $vars['line'];
-			$substitutions['lines'][$key]['linenumber'] = $linenumber;
-			// 'ref' => $line->product_ref,
-			// 'label' => $line->label,
-			// 'description' => $line->desc,
-			// 'product_label' => $line->product_label,
-			// 'product_description' => $line->product_desc,
-			// 'subprice' => price($line->subprice),
-			// 'total_ht' => price($line->total_ht),
-			// 'total_ttc' => price($line->total_ttc),
-			// 'vatrate' => price($line->tva_tx) . '%',
-			// 'special_code' => $line->special_code,
-			// 'product_type' => $line->product_type;
-			// 'line_options' => [];
-			// 'product_options' => [];
-			// var_dump($substitutions['lines'][$key]);
-			if (empty($line->special_code)) {
-				$linenumber++;
-			}
-		}
 
-		// var_dump($substitutions);
+		$substitutions = array_merge($substitutions, ['lines' => $this->buildLinesSubstitutions($object, $outputlangs)]);
+
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -514,7 +211,7 @@ class doc_easydoc_contract_html extends ModelePDFContract
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -522,15 +219,14 @@ class doc_easydoc_contract_html extends ModelePDFContract
 			'margin_right' => $this->marge_droite,
 			'margin_top' => $this->marge_haute,
 			'margin_bottom' => $this->marge_basse,
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("Contract") . " " . $outputlangs->convToOutputCharset($object->thirdparty->name));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('Contract') . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name));
 		$text = getDolGlobalString('CONTRACT_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -539,153 +235,10 @@ class doc_easydoc_contract_html extends ModelePDFContract
 		$mpdf->showWatermarkText = ($object->status == Contrat::STATUS_DRAFT && getDolGlobalString('CONTRACT_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfOrderTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->contract->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
-
-		if (!empty($conf->contract->dir_output)) {
-			$dir = $conf->contract->multidir_output[$object->entity];
-			$objectref = dol_sanitizeFileName($object->ref);
-			if (!preg_match('/specimen/i', $objectref)) {
-				$dir .= "/" . $objectref;
-			}
-			$file = $dir . "/" . $objectref . ".odt";
-
-			if (!file_exists($dir)) {
-				if (dol_mkdir($dir) < 0) {
-					$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-					return -1;
-				}
-			}
-
-			if (file_exists($dir)) {
-				//print "srctemplatepath=".$srctemplatepath;	// Src filename
-				$newfile = basename($srctemplatepath);
-				$newfiletmp = preg_replace('/\.od[ts]/i', '', $newfile);
-				$newfiletmp = preg_replace('/template_/i', '', $newfiletmp);
-				$newfiletmp = preg_replace('/modele_/i', '', $newfiletmp);
-				$newfiletmp = $objectref . '_' . $newfiletmp;
-
-				// Get extension (ods or odt)
-				$newfileformat = substr($newfile, strrpos($newfile, '.') + 1);
-				if (getDolGlobalInt('MAIN_DOC_USE_TIMING')) {
-					$format = getDolGlobalInt('MAIN_DOC_USE_TIMING');
-					if ($format == '1') {
-						$format = '%Y%m%d%H%M%S';
-					}
-					$filename = $newfiletmp . '-' . dol_print_date(dol_now(), $format) . '.' . $newfileformat;
-				} else {
-					$filename = $newfiletmp . '.' . $newfileformat;
-				}
-				$file = $dir . '/' . $filename;
-
-				dol_mkdir($conf->contract->dir_temp);
-				if (!is_writable($conf->contract->dir_temp)) {
-					$this->error = $langs->transnoentities("ErrorFailedToWriteInTempDirectory", $conf->contract->dir_temp);
-					dol_syslog('Error in write_file: ' . $this->error, LOG_ERR);
-					return -1;
-				}
-
-				// Define substitution array
-				$substitutionarray = getCommonSubstitutionArray($outputlangs, 0, null, $object);
-				$array_object_from_properties = $this->get_substitutionarray_each_var_object($object, $outputlangs);
-				$array_objet = $this->get_substitutionarray_object($object, $outputlangs);
-				$array_user = $this->get_substitutionarray_user($user, $outputlangs);
-				$array_soc = $this->get_substitutionarray_mysoc($mysoc, $outputlangs);
-				$array_thirdparty = $this->get_substitutionarray_thirdparty($socobject, $outputlangs);
-				$array_other = $this->get_substitutionarray_other($outputlangs);
-				// retrieve contact information for use in object as contact_xxx tags
-				$array_thirdparty_contact = [];
-
-				if ($usecontact && is_object($contactobject)) {
-					$array_thirdparty_contact = $this->get_substitutionarray_contact($contactobject, $outputlangs, 'contact');
-				}
-
-				$tmparray = array_merge($substitutionarray, $array_object_from_properties, $array_user, $array_soc, $array_thirdparty, $array_objet, $array_other, $array_thirdparty_contact);
-				complete_substitutions_array($tmparray, $outputlangs, $object);
-
-				// Call the ODTSubstitution hook
-				$parameters = ['odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray];
-				$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
-
-				foreach ($tmparray as $key => $value) {
-				}
-				// Replace tags of lines
-				try {
-					$foundtagforlines = 1;
-
-					if ($foundtagforlines) {
-						$linenumber = 0;
-						foreach ($object->lines as $line) {
-							$linenumber++;
-							$tmparray = $this->get_substitutionarray_lines($line, $outputlangs, $linenumber);
-							complete_substitutions_array($tmparray, $outputlangs, $object, $line, "completesubstitutionarray_lines");
-							// Call the ODTSubstitutionLine hook
-							$parameters = ['odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray, 'line' => $line];
-							$reshook = $hookmanager->executeHooks('ODTSubstitutionLine', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
-							foreach ($tmparray as $key => $val) {
-							}
-						}
-					}
-				} catch (OdfException $e) {
-					$this->error = $e->getMessage();
-					dol_syslog($this->error, LOG_WARNING);
-					return -1;
-				}
-
-				// Replace labels translated
-				$tmparray = $outputlangs->get_translations_for_substitutions();
-
-				// Call the beforeODTSave hook
-				$parameters = ['odfHandler' => &$odfHandler, 'file' => $file, 'object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$tmparray];
-				$reshook = $hookmanager->executeHooks('beforeODTSave', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
-
-				$parameters = [
-					'file' => $file,
-					'object' => $object,
-					'outputlangs' => $outputlangs,
-					'outputlangsbis' => $outputlangsbis,
-					'substitutionarray' => &$tmparray
-				];
-				// Note that $action and $object may have been modified by some hooks
-				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
-
-				$this->result = ['fullpath' => $file];
-
-				return 1; // Success
-			} else {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		return -1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->contract->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/expedition/doc/doc_easydoc_expedition_html.modules.php
+++ b/core/modules/expedition/doc/doc_easydoc_expedition_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for expeditions
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/expedition/modules_expedition.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
@@ -39,6 +37,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -47,34 +46,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_expedition_html extends ModelePDFExpedition
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'EXPEDITION_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'expeditions';
 		$this->update_main_doc_field = 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -84,137 +76,27 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		// $texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		// $texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$nametostore = str_replace(DOL_DATA_ROOT, 'DOL_DATA_ROOT', $file['fullname']);
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=expeditions/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$url = $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name']));
-				$text .= '&nbsp;<a class="reposition" href="' . $url . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '&nbsp;';
-				if (getDolGlobalString('EXPEDITION_ADDON_PDF') == 'easydoc_expedition_html:' . $nametostore) {
-					$text .= img_picto($langs->trans("Default"), 'on');
-				} else {
-					$text .= '<a class="reposition" href="' . $_SERVER["PHP_SELF"] . '?action=setdoc&token=' . newToken() . '&value=' . urlencode('easydoc_expedition_html:' . $nametostore) . '&scan_dir=' . urlencode('EXPEDITION_ADDON_EASYDOC_TEMPLATES_PATH') . '&label=' . urlencode('Easydoc templates') . '" alt="' . $langs->trans("Default") . '">' . img_picto($langs->trans("SetAsDefault"), 'off') . '</a>';
-				}
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= '<input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td></tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
 	/**
 	 *  Function to build a document on disk using the generic odt module.
 	 *
-	 *	@param		Expedition  	$object				Object source to build document
+	 *	@param		Expedition  $object				Object source to build document
 	 *	@param		Translate	$outputlangs		Lang output object
 	 * 	@param		string		$srctemplatepath	Full path of source filename for generator using a template file
 	 *  @param		int			$hidedetails		Do not show line details
@@ -228,10 +110,9 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 		global $action, $conf, $hookmanager, $langs, $mysoc, $user, $outputlangsbis;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_expedition_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_expedition_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
-		// if not already done
 		$srctemplatepath = str_replace('DOL_DATA_ROOT', DOL_DATA_ROOT, $srctemplatepath);
 
 		$object->fetch_thirdparty();
@@ -249,92 +130,23 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 			$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'sendings', 'propal', 'bills', 'products', 'orders', 'deliveries', 'banks']);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'propal', 'bills', 'products', 'orders', 'deliveries', 'banks']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'propal', 'bills', 'products', 'orders', 'deliveries', 'banks']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			global $outputlangs, $langs;
-			return price($price, 0, $outputlangs);
-		});
-		$twig->addFunction($function);
-		// create twig function which return json decode
-		$function = new \Twig\TwigFunction('jsondecode', function ($value) {
-			return json_decode($value, true);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -344,216 +156,65 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
+
 		$label_payment_conditions = '';
-		if ($object->cond_reglement_code) {
-			$label_payment_conditions = ($outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
+		if (!empty($object->cond_reglement_code)) {
+			$label_payment_conditions = ($outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
 			$label_payment_conditions = str_replace('\n', "\n", $label_payment_conditions);
-			if ($object->deposit_percent > 0) {
+			if (!empty($object->deposit_percent) && $object->deposit_percent > 0) {
 				$label_payment_conditions = str_replace('__DEPOSIT_PERCENT__', $object->deposit_percent, $label_payment_conditions);
 			}
 		}
-		// Line of free text
-		$newfreetext = '';
+
+		$substitutionarray = [
+			'__FROM_NAME__' => $this->emetteur->name,
+			'__FROM_EMAIL__' => $this->emetteur->email,
+			'__TOTAL_TTC__' => $object->total_ttc,
+			'__TOTAL_HT__' => $object->total_ht,
+			'__TOTAL_VAT__' => $object->total_tva,
+		];
+		complete_substitutions_array($substitutionarray, $langs, $object);
+		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis, 'substitutionarray' => &$substitutionarray];
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+
 		$paramfreetext = 'EXPEDITION_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['phone_mobile_formatted'] = dol_print_phone($mysoc->phone_mobile, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
-
-		// thirdparty
-		$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-				'SERVICE',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-				'SERVICE',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER', 'SERVICE'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER', 'SERVICE'],
 		];
-		$contacts = [];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $idx => $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$res = $contact->fetch($idc);
-					if ($res < 0) {
-						setEventMessages($contact->error, $contact->errors, 'errors');
-					} else {
-						$contacts[strtolower($type) . '_' . $key][$idc] = getEachVarObject($contact, $outputlangs, 0, $idc)[$idc];
-					}
-				}
-				if (!empty($contacts[strtolower($type) . '_' . $key])) {
-					foreach ($contacts[strtolower($type) . '_' . $key] as $jdx => $substitution) {
-						if (!empty($substitution['photo'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['picture'] = $conf->{$substitution['element']}->multidir_output[$conf->entity] . '/' . $substitution['id'] . '/photos/' . $substitution['photo'];
-						}
-						if (!empty($substitution['phone'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['phone_formatted'] = dol_print_phone($substitution['phone'], $substitution['country_code'], 0, 0, '', ' ');
-						}
-						if (!empty($substitution['phone_perso'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['phone_perso_formatted'] = dol_print_phone($substitution['phone_perso'], $substitution['country_code'], 0, 0, '', ' ');
-						}
-						if (!empty($substitution['phone_mobile'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['phone_mobile_formatted'] = dol_print_phone($substitution['phone_mobile'], $substitution['country_code'], 0, 0, '', ' ');
-						}
-					}
-				}
-			}
-		}
-		$substitutions = array_merge($substitutions, $contacts);
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutions($object, $outputlangs, $typescontact));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
-			'lines' => [],
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'labelpaymentconditions' => $label_payment_conditions,
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		$linesarray = [];
-		foreach ($object->lines as $key => $line) {
-			$subtotal_ht += $line->total_ht;
-			$subtotal_ttc += $line->total_ttc;
-			if ($line->special_code == 104777 && $line->qty == 99) {
-				$line->total_ht = $subtotal_ht;
-				$line->total_ttc = $subtotal_ttc;
-				$subtotal_ht = 0;
-				$subtotal_ttc = 0;
-			}
-			$linearray = getEachVarObject($line, $outputlangs, 1, 'line');
-			$linesarray[$key] = $linearray['line'];
-			$linesarray[$key]['linenumber'] = $linenumber;
-			$linesarray[$key]['subtotal_ht'] = $subtotal_ht;
-			if ($line->fk_product > 0) {
-				$product = new Product($this->db);
-				$product->fetch($line->fk_product);
-				$linesarray[$key]['product'] = getEachVarObject($product, $outputlangs)['object'];
-				$cat = new Categorie($this->db);
-				$linesarray[$key]['categories'] = $cat->getListForItem($line->fk_product, 'product');
-				$linesarray[$key]['photos'] = [];
-				$pdir = [];
-				if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
-					$pdir[0] = get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . "/photos/";
-					$pdir[1] = get_exdir(0, 0, 0, 0, $product, 'product') . dol_sanitizeFileName($product->ref) . '/';
-				} else {
-					$pdir[0] = get_exdir(0, 0, 0, 0, $product, 'product'); // default
-					$pdir[1] = get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . "/photos/"; // alternative
-				}
-				foreach ($pdir as $midir) {
-					if ($conf->entity != $product->entity) {
-						$dir = $conf->product->multidir_output[$product->entity] . '/' . $midir; //Check repertories of current entities
-					} else {
-						$dir = $conf->product->dir_output . '/' . $midir; //Check repertory of the current product
-					}
-					foreach ($product->liste_photos($dir, 1) as $photokey => $obj) {
-						// if (!getDolGlobalInt('CAT_HIGH_QUALITY_IMAGES')) {		// If CAT_HIGH_QUALITY_IMAGES not defined, we use thumb if defined and then original photo
-						// 	if ($obj['photo_vignette']) {
-						// 		$filename = $obj['photo_vignette'];
-						// 	} else {
-						// 		$filename = $obj['photo'];
-						// 	}
-						// } else {
-						$filename = $obj['photo'];
-						// }
 
-						$linesarray[$key]['photos'][] = $dir . $filename;
-					}
-				}
-			}
+		// Expedition: extended lines (categories, photos), recursive=true
+		$substitutions = array_merge($substitutions, ['lines' => $this->buildExtendedLinesSubstitutions($object, $outputlangs, true)]);
 
-			// $substitutions['lines'][$key] = [
-			// 	'linenumber' => $linenumber,
-			// 	'qty' => $line->qty,
-			// 	'ref' => $line->product_ref,
-			// 	'label' => $line->label,
-			// 	'description' => $line->desc,
-			// 	'product_label' => $line->product_label,
-			// 	'product_description' => $line->product_desc,
-			// 	'subprice' => $line->subprice,
-			// 	'total_ht' => $line->total_ht,
-			// 	'total_ttc' => $line->total_ttc,
-			// 	'vatrate' => $line->tva_tx,
-			// 	'special_code' => $line->special_code,
-			// 	'product_type' => $line->product_type,
-			// 	'line_options' => [],
-			// 	'product_options' => [],
-			// ];
-			if (empty($line->special_code)) {
-				$linenumber++;
-			}
-		}
-		$substitutions = array_merge($substitutions, ['lines' => $linesarray]);
-
-		$substitutions['parameters'] = [
-			'hidedetails' => $hidedetails,
-			'hidedesc' => $hidedesc,
-			'hideref' => $hideref,
-		];
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -563,7 +224,7 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -571,16 +232,14 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['copy', 'print', 'modify', 'annot-forms', 'fill-forms', 'extract', 'assemble', 'print-highres']);
-		// $mpdf->SetProtection([]); // deny all
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("PdfCommercialProposalTitle") . " " . $outputlangs->convToOutputCharset($object->thirdparty->name));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('PdfCommercialProposalTitle') . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name));
 		$text = getDolGlobalString('EXPEDITION_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -589,44 +248,15 @@ class doc_easydoc_expedition_html extends ModelePDFExpedition
 		$mpdf->showWatermarkText = ($object->status == Expedition::STATUS_DRAFT && getDolGlobalString('EXPEDITION_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('Shipment'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->expedition->multidir_output[$object->entity];
+		// Expedition stores PDFs in a /sending/ subdirectory
 		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/sending/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
+		$dirbase = $conf->expedition->multidir_output[$object->entity];
+		$dir = preg_match('/specimen/i', $objectref) ? $dirbase : $dirbase . '/sending';
 
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$parameters = [
-			'file' => $file,
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		// Note that $action and $object may have been modified by some hooks
-		$hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $dir, $srctemplatepath);
 	}
 }

--- a/core/modules/expensereport/doc/doc_easydoc_expensereport_html.modules.php
+++ b/core/modules/expensereport/doc/doc_easydoc_expensereport_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for expensereports
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/expensereport/modules_expensereport.php';
 require_once DOL_DOCUMENT_ROOT . '/expensereport/class/expensereport.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
@@ -37,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -45,34 +44,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_expensereport_html extends ModeleExpenseReport
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
-		$langs->loadLangs(["main", "companies", "easydocgenerator@easydocgenerator"]);
+		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'EXPENSEREPORT_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'expensereports';
 		$this->update_main_doc_field = ((int) DOL_VERSION < 20) ? 0 : 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -82,124 +74,20 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $conf, $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		// $texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		// $texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=expensereports/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$text .= ' &nbsp; <a class="reposition" href="' . $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name'])) . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -207,20 +95,20 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 	 *  Function to build a document on disk using the generic odt module.
 	 *
 	 *	@param		ExpenseReport 	$object				Object source to build document
-	 *	@param		Translate	$outputlangs		Lang output object
-	 * 	@param		string		$srctemplatepath	Full path of source filename for generator using a template file
-	 *  @param		int			$hidedetails		Do not show line details
-	 *  @param		int			$hidedesc			Do not show desc
-	 *  @param		int			$hideref			Do not show ref
-	 *	@return		int         					1 if OK, <=0 if KO
+	 *	@param		Translate		$outputlangs		Lang output object
+	 * 	@param		string			$srctemplatepath	Full path of source filename for generator using a template file
+	 *  @param		int				$hidedetails		Do not show line details
+	 *  @param		int				$hidedesc			Do not show desc
+	 *  @param		int				$hideref			Do not show ref
+	 *	@return		int         						1 if OK, <=0 if KO
 	 */
 	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
 	{
 		// phpcs:enable
-		global $user, $langs, $conf, $mysoc, $hookmanager;
+		global $action, $user, $langs, $conf, $mysoc, $hookmanager;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_expensereport_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_expensereport_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -229,97 +117,34 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 		if (!is_object($outputlangs)) {
 			$outputlangs = $langs;
 		}
-		$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'trips', 'compta', 'easydocgenerator@easydocgenerator']);
+		$langfiles = ['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'trips', 'compta', 'easydocgenerator@easydocgenerator'];
+		$outputlangs->loadLangs($langfiles);
 
 		global $outputlangsbis;
 		$outputlangsbis = null;
 		if (getDolGlobalString('PDF_USE_ALSO_LANGUAGE_CODE') && $outputlangs->defaultlang != getDolGlobalString('PDF_USE_ALSO_LANGUAGE_CODE')) {
 			$outputlangsbis = new Translate('', $conf);
 			$outputlangsbis->setDefaultLang(getDolGlobalString('PDF_USE_ALSO_LANGUAGE_CODE'));
-			$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'trips', 'compta', 'easydocgenerator@easydocgenerator']);
+			$outputlangsbis->loadLangs($langfiles);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		global $action;
-		$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			return price($price, 0);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -329,127 +154,31 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
 
-		// Recipient name
-		$contactobject = null;
-		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
-				$object->contact->fetch_thirdparty();
-				$socobject = $object->contact->thirdparty;
-				$contactobject = $object->contact;
-			} else {
-				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
-				$contactobject = $object->contact;
-			}
-		} else {
-			$socobject = $object->thirdparty;
-		}
-
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis, 'substitutionarray' => &$substitutionarray];
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Call the ODTSubstitution hook
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-			'substitutionarray' => &$substitutionarray,
-		];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
-
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'EXPENSEREPORT_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
-		if (getDolGlobalInt('EXPENSEREPORT_USE_OLD_PATH_FOR_PHOTO')) {
-			$pdir[0] = get_exdir($object->id, 2, 0, 0, $object, 'expensereport') . $object->id . "/photos/";
-			$pdir[1] = get_exdir(0, 0, 0, 0, $object, 'expensereport') . dol_sanitizeFileName($object->ref) . '/';
-		} else {
-			$pdir[0] = get_exdir(0, 0, 0, 0, $object, 'expensereport'); // default
-			$pdir[1] = get_exdir($object->id, 2, 0, 0, $object, 'expensereport') . $object->id . "/photos/"; // alternative
-		}
-		$pictures = [];
-		// foreach ($pdir as $midir) {
-		// 	if ($conf->entity != $object->entity) {
-		// 		$dir = $conf->expensereport->multidir_output[$object->entity] . '/' . $midir; //Check repertories of current entities
-		// 	} else {
-		// 		$dir = $conf->expensereport->dir_output . '/' . $midir; //Check repertory of the current expensereport
-		// 	}
-		// 	foreach ($object->liste_photos($dir) as $key => $obj) {
-		// 		$exif = '';
-		// 		if (function_exists('exif_read_data')) {
-		// 			$exif = exif_read_data($dir . $obj['photo']);
-		// 		}
-		// 		if ($obj['photo_vignette']) {
-		// 			$pictures[] = [
-		// 				'dir' => $dir,
-		// 				'thumb' => $obj['photo_vignette'],
-		// 				'original' => $obj['photo'],
-		// 				'exif' => $exif,
-		// 			];
-		// 		} else {
-		// 			$pictures[] = [
-		// 				'dir' => $dir,
-		// 				'original' => $obj['photo'],
-		// 				'exif' => $exif,
-		// 			];
-		// 		}
-		// 	}
-		// }
-		$substitutions = array_merge($substitutions, ['pictures' => $pictures]);
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
@@ -457,47 +186,14 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		// var_dump($substitutions);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		// foreach ($object->lines as $key => $line) {
-		// 	$subtotal_ht += $line->total_ht;
-		// 	$subtotal_ttc += $line->total_ttc;
-		// 	if ($line->special_code == 104777 && $line->qty == 99) {
-		// 		$line->total_ht = $subtotal_ht;
-		// 		$line->total_ttc = $subtotal_ttc;
-		// 		$subtotal_ht = 0;
-		// 		$subtotal_ttc = 0;
-		// 	}
-		// 	$substitutions['lines'][$key] = [
-		// 		'linenumber' => $linenumber,
-		// 		'qty' => $line->qty,
-		// 		'ref' => $line->product_ref,
-		// 		'label' => $line->label,
-		// 		'description' => $line->desc,
-		// 		'product_label' => $line->product_label,
-		// 		'product_description' => $line->product_desc,
-		// 		'subprice' => price($line->subprice),
-		// 		'total_ht' => price($line->total_ht),
-		// 		'total_ttc' => price($line->total_ttc),
-		// 		'vatrate' => price($line->tva_tx) . '%',
-		// 		'special_code' => $line->special_code,
-		// 		'product_type' => $line->product_type,
-		// 		'line_options' => [],
-		// 		'product_options' => [],
-		// 	];
-		// 	if (empty($line->special_code)) {
-		// 		$linenumber++;
-		// 	}
-		// }
 
-		// var_dump($substitutions);
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -507,7 +203,7 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -515,15 +211,14 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
-		$mpdf->SetTitle($outputlangs->convToOutputCharset("Product"));
+		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("Product"));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('ExpenseReport'));
 		$text = getDolGlobalString('EXPENSEREPORT_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -532,35 +227,10 @@ class doc_easydoc_expensereport_html extends ModeleExpenseReport
 		$mpdf->showWatermarkText = (!$object->status_buy && getDolGlobalString('EXPENSEREPORT_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfProductTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->expensereport->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->expensereport->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/facture/doc/doc_easydoc_invoice_html.modules.php
+++ b/core/modules/facture/doc/doc_easydoc_invoice_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for invoices
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/facture/modules_facture.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/contact/class/contact.class.php';
@@ -38,7 +36,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
-dol_include_once('/easydocgenerator/vendor/autoload.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -47,34 +45,27 @@ dol_include_once('/easydocgenerator/vendor/autoload.php');
 class doc_easydoc_invoice_html extends ModelePDFFactures
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'INVOICE_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'invoices';
 		$this->update_main_doc_field = 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -84,122 +75,20 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $conf, $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="INVOICE_ADDON_EASYDOC_TEMPLATES_PATH">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim($conf->global->INVOICE_ADDON_EASYDOC_TEMPLATES_PATH)));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		// $texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		// $texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString('INVOICE_ADDON_EASYDOC_TEMPLATES_PATH');
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString('INVOICE_ADDON_EASYDOC_TEMPLATES_PATH')) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=invoices/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$text .= ' &nbsp; <a class="reposition" href="' . $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=INVOICE_ADDON_EASYDOC_TEMPLATES_PATH&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name'])) . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="INVOICE_ADDON_EASYDOC_TEMPLATES_PATH" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td></tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -217,10 +106,10 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
 	{
 		// phpcs:enable
-		global $action, $conf, $hookmanager, $langs, $mysoc, $user, $outputlangsbis;
+		global $action, $langs, $conf, $mysoc, $hookmanager, $user;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_invoice_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_invoice_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -232,6 +121,7 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 		$langfiles = ['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'compta', 'easydocgenerator@easydocgenerator'];
 		$outputlangs->loadLangs($langfiles);
 
+		global $outputlangsbis;
 		$outputlangsbis = null;
 		if (getDolGlobalString('PDF_USE_ALSO_LANGUAGE_CODE') && $outputlangs->defaultlang != getDolGlobalString('PDF_USE_ALSO_LANGUAGE_CODE')) {
 			$outputlangsbis = new Translate('', $conf);
@@ -239,87 +129,24 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 			$outputlangsbis->loadLangs($langfiles);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
 		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-			'debug' => true,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'easydocgenerator@easydocgenerator', 'compta']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'easydocgenerator@easydocgenerator', 'compta']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			global $outputlangs, $langs;
-			return price($price, 0, $outputlangs);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -329,240 +156,110 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
+
 		$label_payment_conditions = '';
 		if ($object->cond_reglement_code) {
-			$label_payment_conditions = ($outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
+			$label_payment_conditions = ($outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
 			$label_payment_conditions = str_replace('\n', "\n", $label_payment_conditions);
 			if ($object->deposit_percent > 0) {
 				$label_payment_conditions = str_replace('__DEPOSIT_PERCENT__', $object->deposit_percent, $label_payment_conditions);
 			}
 		}
-		// If CUSTOMER contact defined on invoice, we use it
+
 		$usecontact = false;
 		$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
 		if (count($arrayidcontact) > 0) {
 			$usecontact = true;
 			$result = $object->fetch_contact($arrayidcontact[0]);
 		}
-
-		// Recipient name
 		$contactobject = null;
 		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
 			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
 				$object->contact->fetch_thirdparty();
 				$socobject = $object->contact->thirdparty;
 				$contactobject = $object->contact;
 			} else {
 				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
 				$contactobject = $object->contact;
 			}
 		} else {
 			$socobject = $object->thirdparty;
 		}
 
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
-
-		// Call the ODTSubstitution hook
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$substitutionarray];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'INVOICE_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['phone_mobile_formatted'] = dol_print_phone($mysoc->phone_mobile, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
+
 		$qrcodestring = '';
 		if (getDolGlobalString('INVOICE_ADD_ZATCA_QR_CODE')) {
 			$qrcodestring = $object->buildZATCAQRString();
 		} elseif (getDolGlobalString('INVOICE_ADD_SWISS_QR_CODE') == '1') {
 			$qrcodestring = $object->buildSwitzerlandQRString();
 		}
-		// Add online_payment_url, copied from irder
 		require_once DOL_DOCUMENT_ROOT . '/core/lib/payments.lib.php';
 		$online_payment_url = getOnlinePaymentUrl(0, 'invoice', $object->ref);
+
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
 		$substitutions['object']['qrcodestring'] = $qrcodestring;
 		$substitutions['object']['online_payment_url'] = $online_payment_url;
 
-		// thirdparty
-		$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
 		];
-		$contacts = [];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $idx => $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$res = $contact->fetch($idc);
-					if ($res < 0) {
-						setEventMessages($contact->error, $contact->errors, 'errors');
-					} else {
-						$contacts[strtolower($type) . '_' . $key][$idc] = getEachVarObject($contact, $outputlangs, 0, $idc)[$idc];
-					}
-				}
-				if (!empty($contacts[strtolower($type) . '_' . $key])) {
-					foreach ($contacts[strtolower($type) . '_' . $key] as $jdx => $substitution) {
-						if (!empty($substitution['photo'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['picture'] = $conf->{$substitution['element']}->multidir_output[$conf->entity] . '/' . $substitution['id'] . '/photos/' . $substitution['photo'];
-						}
-					}
-				}
-			}
-		}
-		$substitutions = array_merge($substitutions, $contacts);
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutions($object, $outputlangs, $typescontact));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
-			'lines' => [],
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'labelpaymentconditions' => $label_payment_conditions,
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		$linesarray = [];
-		foreach ($object->lines as $key => $line) {
-			$subtotal_ht += $line->total_ht;
-			$subtotal_ttc += $line->total_ttc;
-			if ($line->special_code == 104777 && $line->qty == 99) {
-				$line->total_ht = $subtotal_ht;
-				$line->total_ttc = $subtotal_ttc;
-				$subtotal_ht = 0;
-				$subtotal_ttc = 0;
-			}
-			$linearray = getEachVarObject($line, $outputlangs, 1, 'line');
-			$linesarray[$key] = $linearray['line'];
-			$linesarray[$key]['linenumber'] = $linenumber;
-			$linesarray[$key]['subtotal_ht'] = $subtotal_ht;
-			if ($line->fk_product > 0) {
-				$product = new Product($this->db);
-				$product->fetch($line->fk_product);
-				$linesarray[$key]['product'] = getEachVarObject($product, $outputlangs)['object'];
-			}
 
-			// $substitutions['lines'][$key] = [
-			// 	'linenumber' => $linenumber,
-			// 	'qty' => $line->qty,
-			// 	'ref' => $line->product_ref,
-			// 	'label' => $line->label,
-			// 	'description' => $line->desc,
-			// 	'product_label' => $line->product_label,
-			// 	'product_description' => $line->product_desc,
-			// 	'subprice' => $line->subprice,
-			// 	'total_ht' => $line->total_ht,
-			// 	'total_ttc' => $line->total_ttc,
-			// 	'vatrate' => $line->tva_tx,
-			// 	'special_code' => $line->special_code,
-			// 	'product_type' => $line->product_type,
-			// 	'line_options' => [],
-			// 	'product_options' => [],
-			// ];
-			if (empty($line->special_code)) {
-				$linenumber++;
-			}
-		}
-		$substitutions = array_merge($substitutions, ['lines' => $linesarray]);
+		$substitutions = array_merge($substitutions, ['lines' => $this->buildLinesSubstitutions($object, $outputlangs, true)]);
 
-		// Discounts
+		// Invoice-specific: discounts
 		$substitutions['discounts'] = [];
-		// Loop on each discount available (deposits and credit notes and excess of payment included)
-		$sql = "SELECT re.rowid, re.amount_ht, re.multicurrency_amount_ht, re.amount_tva, re.multicurrency_amount_tva,  re.amount_ttc, re.multicurrency_amount_ttc,";
-		$sql .= " re.description, re.fk_facture_source,";
-		$sql .= " f.type, f.datef";
-		$sql .= " FROM " . MAIN_DB_PREFIX . "societe_remise_except as re, " . MAIN_DB_PREFIX . "facture as f";
-		$sql .= " WHERE re.fk_facture_source = f.rowid AND re.fk_facture = " . ((int) $object->id);
+		$sql = 'SELECT re.rowid, re.amount_ht, re.multicurrency_amount_ht, re.amount_tva, re.multicurrency_amount_tva, re.amount_ttc, re.multicurrency_amount_ttc,';
+		$sql .= ' re.description, re.fk_facture_source, f.type, f.datef';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'societe_remise_except as re, ' . MAIN_DB_PREFIX . 'facture as f';
+		$sql .= ' WHERE re.fk_facture_source = f.rowid AND re.fk_facture = ' . ((int) $object->id);
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			$num = $this->db->num_rows($resql);
-			$i = 0;
 			$invoice = new Facture($this->db);
-			while ($i < $num) {
-				$obj = $this->db->fetch_object($resql);
+			while ($obj = $this->db->fetch_object($resql)) {
 				if ($obj->type == 2) {
-					$text = "CreditNote";
+					$text = 'CreditNote';
 				} elseif ($obj->type == 3) {
-					$text = "Deposit";
+					$text = 'Deposit';
 				} elseif ($obj->type == 0) {
-					$text = "ExcessReceived";
+					$text = 'ExcessReceived';
 				} else {
-					$text = "UnknownType";
+					$text = 'UnknownType';
 				}
 				$invoice->fetch($obj->fk_facture_source);
 				$substitutions['discounts'][] = [
@@ -572,53 +269,34 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 					'total_ttc' => $obj->amount_ttc,
 					'multicurrency_total_ttc' => $obj->multicurrency_amount_ttc,
 				];
-				$i++;
 			}
 		}
-		$substitutions['payments'] = [];
-		// Loop on each payment
-		// $sql = "SELECT p.datep as date, p.fk_paiement, p.num_paiement as num, pf.amount as amount, pf.multicurrency_amount,";
-		// $sql .= " cp.code, ba.ref as bankref";
-		// $sql .= " FROM " . MAIN_DB_PREFIX . "paiement_facture as pf";
-		// $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "paiement as p ON  pf.fk_paiement = p.rowid";
-		// $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "c_paiement AS cp ON p.fk_paiement = cp.id AND cp.entity IN (" . getEntity('c_paiement') . ")";
-		// $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "bank as b ON p.fk_bank = b.rowid";
-		// $sql .= " INNER JOIN " . MAIN_DB_PREFIX . "bank_account as ba ON b.fk_account = ba.rowid";
-		// $sql .= " WHERE pf.fk_facture = " . ((int) $object->id);
-		// $sql .= " ORDER BY p.datep";
-		$sql = "SELECT p.datep as date, p.fk_paiement, p.num_paiement as num, pf.amount as amount, pf.multicurrency_amount,";
-		$sql .= " cp.code";
-		$sql .= " FROM " . MAIN_DB_PREFIX . "paiement_facture as pf, " . MAIN_DB_PREFIX . "paiement as p";
-		$sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "c_paiement as cp ON p.fk_paiement = cp.id";
-		$sql .= " WHERE pf.fk_paiement = p.rowid AND pf.fk_facture = " . ((int) $object->id);
-		// $sql.= " WHERE pf.fk_paiement = p.rowid AND pf.fk_facture = 1";
-		$sql .= " ORDER BY p.datep";
 
+		// Invoice-specific: payments
+		$substitutions['payments'] = [];
+		$sql = 'SELECT p.datep as date, p.fk_paiement, p.num_paiement as num, pf.amount as amount, pf.multicurrency_amount, cp.code';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'paiement_facture as pf, ' . MAIN_DB_PREFIX . 'paiement as p';
+		$sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'c_paiement as cp ON p.fk_paiement = cp.id';
+		$sql .= ' WHERE pf.fk_paiement = p.rowid AND pf.fk_facture = ' . ((int) $object->id);
+		$sql .= ' ORDER BY p.datep';
 		$resql = $this->db->query($sql);
 		if ($resql) {
-			$num = $this->db->num_rows($resql);
-			$i = 0;
-			while ($i < $num) {
-				$obj = $this->db->fetch_object($resql);
+			while ($obj = $this->db->fetch_object($resql)) {
 				$substitutions['payments'][] = [
-					'text' => "PaymentTypeShort" . $obj->code,
+					'text' => 'PaymentTypeShort' . $obj->code,
 					'date' => $this->db->jdate($obj->date),
 					'num' => $obj->num,
 					'total_ttc' => $obj->amount,
 					'multicurrency_total_ttc' => $obj->multicurrency_amount,
-					//'bankref' => $obj->bankref,
 				];
-				$i++;
 			}
 		}
-		$substitutions['parameters'] = [
-			'hidedetails' => $hidedetails,
-			'hidedesc' => $hidedesc,
-			'hideref' => $hideref,
-		];
+
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -628,7 +306,7 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -636,15 +314,14 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("PdfInvoiceTitle") . " " . $outputlangs->convToOutputCharset($object->thirdparty->name));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('PdfInvoiceTitle') . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name));
 		$text = getDolGlobalString('FACTURE_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -653,43 +330,10 @@ class doc_easydoc_invoice_html extends ModelePDFFactures
 		$mpdf->showWatermarkText = ($object->status == Facture::STATUS_DRAFT && getDolGlobalString('FACTURE_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfInvoiceTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->facture->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$parameters = [
-			'file' => $file,
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-		];
-		// Note that $action and $object may have been modified by some hooks
-		$hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->facture->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/product/doc/doc_easydoc_product_html.modules.php
+++ b/core/modules/product/doc/doc_easydoc_product_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for products
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/product/modules_product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
@@ -37,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -45,34 +44,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_product_html extends ModelePDFProduct
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
-		$langs->loadLangs(["main", "companies", "easydocgenerator@easydocgenerator"]);
+		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'products';
 		$this->update_main_doc_field = ((int) DOL_VERSION < 20) ? 0 : 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -82,124 +74,20 @@ class doc_easydoc_product_html extends ModelePDFProduct
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $conf, $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString('PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH'))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		// $texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		// $texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString('PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH');
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString('PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH')) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=products/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$text .= ' &nbsp; <a class="reposition" href="' . $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name'])) . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="PRODUCT_ADDON_EASYDOC_TEMPLATES_PATH" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -217,10 +105,10 @@ class doc_easydoc_product_html extends ModelePDFProduct
 	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
 	{
 		// phpcs:enable
-		global $user, $langs, $conf, $mysoc, $hookmanager;
+		global $action, $user, $langs, $conf, $mysoc, $hookmanager;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_product_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_product_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -229,7 +117,8 @@ class doc_easydoc_product_html extends ModelePDFProduct
 		if (!is_object($outputlangs)) {
 			$outputlangs = $langs;
 		}
-		$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'easydocgenerator@easydocgenerator']);
+		$langfiles = ['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'easydocgenerator@easydocgenerator'];
+		$outputlangs->loadLangs($langfiles);
 
 		global $outputlangsbis;
 		$outputlangsbis = null;
@@ -239,83 +128,23 @@ class doc_easydoc_product_html extends ModelePDFProduct
 			$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks']);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs];
-		global $action;
-		$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'easydocgenerator@easydocgenerator']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			return price($price, 0);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -325,122 +154,58 @@ class doc_easydoc_product_html extends ModelePDFProduct
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
 
-		// Recipient name
-		$contactobject = null;
-		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
-				$object->contact->fetch_thirdparty();
-				$socobject = $object->contact->thirdparty;
-				$contactobject = $object->contact;
-			} else {
-				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
-				$contactobject = $object->contact;
-			}
-		} else {
-			$socobject = $object->thirdparty;
-		}
-
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
-
-		// Call the ODTSubstitution hook
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$substitutionarray];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'PRODUCT_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		// Build product photos
 		if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
-			$pdir[0] = get_exdir($object->id, 2, 0, 0, $object, 'product') . $object->id . "/photos/";
+			$pdir[0] = get_exdir($object->id, 2, 0, 0, $object, 'product') . $object->id . '/photos/';
 			$pdir[1] = get_exdir(0, 0, 0, 0, $object, 'product') . dol_sanitizeFileName($object->ref) . '/';
 		} else {
-			$pdir[0] = get_exdir(0, 0, 0, 0, $object, 'product'); // default
-			$pdir[1] = get_exdir($object->id, 2, 0, 0, $object, 'product') . $object->id . "/photos/"; // alternative
+			$pdir[0] = get_exdir(0, 0, 0, 0, $object, 'product');
+			$pdir[1] = get_exdir($object->id, 2, 0, 0, $object, 'product') . $object->id . '/photos/';
 		}
 		$pictures = [];
 		foreach ($pdir as $midir) {
-			if ($conf->entity != $object->entity) {
-				$dir = $conf->product->multidir_output[$object->entity] . '/' . $midir; //Check repertories of current entities
-			} else {
-				$dir = $conf->product->dir_output . '/' . $midir; //Check repertory of the current product
-			}
+			$dir = ($conf->entity != $object->entity)
+				? $conf->product->multidir_output[$object->entity] . '/' . $midir
+				: $conf->product->dir_output . '/' . $midir;
 			foreach ($object->liste_photos($dir) as $key => $obj) {
 				$exif = '';
 				if (function_exists('exif_read_data')) {
 					$exif = exif_read_data($dir . $obj['photo']);
 				}
 				if ($obj['photo_vignette']) {
-					$pictures[] = [
-						'dir' => $dir,
-						'thumb' => $obj['photo_vignette'],
-						'original' => $obj['photo'],
-						'exif' => $exif,
-					];
+					$pictures[] = ['dir' => $dir, 'thumb' => $obj['photo_vignette'], 'original' => $obj['photo'], 'exif' => $exif];
 				} else {
-					$pictures[] = [
-						'dir' => $dir,
-						'original' => $obj['photo'],
-						'exif' => $exif,
-					];
+					$pictures[] = ['dir' => $dir, 'original' => $obj['photo'], 'exif' => $exif];
 				}
 			}
 		}
+
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, ['pictures' => $pictures]);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
@@ -448,47 +213,14 @@ class doc_easydoc_product_html extends ModelePDFProduct
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		// var_dump($substitutions);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		// foreach ($object->lines as $key => $line) {
-		// 	$subtotal_ht += $line->total_ht;
-		// 	$subtotal_ttc += $line->total_ttc;
-		// 	if ($line->special_code == 104777 && $line->qty == 99) {
-		// 		$line->total_ht = $subtotal_ht;
-		// 		$line->total_ttc = $subtotal_ttc;
-		// 		$subtotal_ht = 0;
-		// 		$subtotal_ttc = 0;
-		// 	}
-		// 	$substitutions['lines'][$key] = [
-		// 		'linenumber' => $linenumber,
-		// 		'qty' => $line->qty,
-		// 		'ref' => $line->product_ref,
-		// 		'label' => $line->label,
-		// 		'description' => $line->desc,
-		// 		'product_label' => $line->product_label,
-		// 		'product_description' => $line->product_desc,
-		// 		'subprice' => price($line->subprice),
-		// 		'total_ht' => price($line->total_ht),
-		// 		'total_ttc' => price($line->total_ttc),
-		// 		'vatrate' => price($line->tva_tx) . '%',
-		// 		'special_code' => $line->special_code,
-		// 		'product_type' => $line->product_type,
-		// 		'line_options' => [],
-		// 		'product_options' => [],
-		// 	];
-		// 	if (empty($line->special_code)) {
-		// 		$linenumber++;
-		// 	}
-		// }
 
-		// var_dump($substitutions);
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -498,7 +230,7 @@ class doc_easydoc_product_html extends ModelePDFProduct
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -506,15 +238,14 @@ class doc_easydoc_product_html extends ModelePDFProduct
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
-		$mpdf->SetTitle($outputlangs->convToOutputCharset("Product"));
+		$mpdf->SetTitle($outputlangs->convToOutputCharset('Product'));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("Product"));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('Product'));
 		$text = getDolGlobalString('PRODUCT_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -523,35 +254,10 @@ class doc_easydoc_product_html extends ModelePDFProduct
 		$mpdf->showWatermarkText = (!$object->status_buy && getDolGlobalString('PRODUCT_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfProductTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->product->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->product->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/propale/doc/doc_easydoc_propale_html.modules.php
+++ b/core/modules/propale/doc/doc_easydoc_propale_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for propales
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/propale/modules_propale.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
@@ -39,7 +37,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
-dol_include_once('/easydocgenerator/vendor/autoload.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -48,34 +46,27 @@ dol_include_once('/easydocgenerator/vendor/autoload.php');
 class doc_easydoc_propale_html extends ModelePDFPropales
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'PROPALE_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'propales';
 		$this->update_main_doc_field = 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -85,130 +76,27 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 		$this->marge_haute = getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48);
 		$this->marge_basse = getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25);
 
-		$this->option_logo = 1;             // Display logo
-		$this->option_tva = 0;              // Manage the vat option COMMANDE_TVAOPTION
-		$this->option_modereg = 0;          // Display payment mode
-		$this->option_condreg = 0;          // Display payment terms
-		$this->option_multilang = 1;        // Available in several languages
-		$this->option_escompte = 0;         // Displays if there has been a discount
-		$this->option_credit_note = 0;      // Support credit notes
-		$this->option_freetext = 1;         // Support add of a personalised text
-		$this->option_draft_watermark = 0;  // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		// $texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		// $texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=propales/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$url = $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . $this->scandir . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name']));
-				$text .= ' &nbsp; <a class="reposition" href="' . $url . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= '<input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td></tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
 	/**
 	 *  Function to build a document on disk using the generic odt module.
 	 *
-	 *	@param		Propal  	$object				Object source to build document
+	 *	@param		Propal		$object				Object source to build document
 	 *	@param		Translate	$outputlangs		Lang output object
 	 * 	@param		string		$srctemplatepath	Full path of source filename for generator using a template file
 	 *  @param		int			$hidedetails		Do not show line details
@@ -220,10 +108,9 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 	{
 		// phpcs:enable
 		global $action, $conf, $hookmanager, $langs, $mysoc, $user, $outputlangsbis;
-		/** @var Conf $conf */
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_propale_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_propale_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -242,91 +129,24 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 			$outputlangsbis->loadLangs($languages);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
 		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
-		$parameters = [
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis];
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		$md5id = md5_file($srctemplatepath);
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$enablecache = getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : (DOL_DATA_ROOT . '/easydocgenerator/temp/' . ($md5id ? $md5id : ''));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => $enablecache,
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-				$outputlangs->loadLangs(['main', 'dict', 'companies', 'propal', 'bills', 'products', 'orders', 'deliveries', 'banks']);
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-				$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'propal', 'bills', 'products', 'orders', 'deliveries', 'banks']);
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			global $outputlangs, $langs;
-			return price($price, 0, $outputlangs);
-		});
-		$twig->addFunction($function);
-		// create twig function which return json decode
-		$function = new \Twig\TwigFunction('jsondecode', function ($value) {
-			return json_decode($value, true);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -336,213 +156,85 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if (!empty($this->emetteur->logo)) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
+
 		$label_payment_conditions = '';
 		if ($object->cond_reglement_code) {
-			$label_payment_conditions = ($outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities("PaymentCondition" . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
+			$label_payment_conditions = ($outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) != 'PaymentCondition' . $object->cond_reglement_code) ? $outputlangs->transnoentities('PaymentCondition' . $object->cond_reglement_code) : $outputlangs->convToOutputCharset($object->cond_reglement_doc ? $object->cond_reglement_doc : $object->cond_reglement_label);
 			$label_payment_conditions = str_replace('\n', "\n", $label_payment_conditions);
 			if ($object->deposit_percent > 0) {
 				$label_payment_conditions = str_replace('__DEPOSIT_PERCENT__', $object->deposit_percent, $label_payment_conditions);
 			}
 		}
-		// Line of free text
-		$newfreetext = '';
+
+		$usecontact = false;
+		$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
+		if (count($arrayidcontact) > 0) {
+			$usecontact = true;
+			$result = $object->fetch_contact($arrayidcontact[0]);
+		}
+		$contactobject = null;
+		if (!empty($usecontact)) {
+			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
+				$object->contact->fetch_thirdparty();
+				$socobject = $object->contact->thirdparty;
+				$contactobject = $object->contact;
+			} else {
+				$socobject = $object->thirdparty;
+				$contactobject = $object->contact;
+			}
+		} else {
+			$socobject = $object->thirdparty;
+		}
+
+		$substitutionarray = [
+			'__FROM_NAME__' => $this->emetteur->name,
+			'__FROM_EMAIL__' => $this->emetteur->email,
+			'__TOTAL_TTC__' => $object->total_ttc,
+			'__TOTAL_HT__' => $object->total_ht,
+			'__TOTAL_VAT__' => $object->total_tva,
+		];
+		complete_substitutions_array($substitutionarray, $langs, $object);
+		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
+		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'outputlangsbis' => $outputlangsbis, 'substitutionarray' => &$substitutionarray];
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+
 		$paramfreetext = 'PROPOSAL_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['phone_mobile_formatted'] = dol_print_phone($mysoc->phone_mobile, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
-
-		// thirdparty
-		$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-				'SERVICE',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-				'SERVICE',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'SERVICE', 'CUSTOMER'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'SERVICE', 'CUSTOMER'],
 		];
-		$contacts = [];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $idx => $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$res = $contact->fetch($idc);
-					if ($res < 0) {
-						setEventMessages($contact->error, $contact->errors, 'errors');
-					} else {
-						$contacts[strtolower($type) . '_' . $key][$idc] = getEachVarObject($contact, $outputlangs, 0, $idc)[$idc];
-					}
-				}
-				if (!empty($contacts[strtolower($type) . '_' . $key])) {
-					foreach ($contacts[strtolower($type) . '_' . $key] as $jdx => $substitution) {
-						if (!empty($substitution['photo'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['picture'] = $conf->{$substitution['element']}->multidir_output[$conf->entity] . '/' . $substitution['id'] . '/photos/' . $substitution['photo'];
-						}
-						if (!empty($substitution['phone'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['phone_formatted'] = dol_print_phone($substitution['phone'], $substitution['country_code'], 0, 0, '', ' ');
-						}
-						if (!empty($substitution['phone_mobile'])) {
-							$contacts[strtolower($type) . '_' . $key][$jdx]['phone_mobile_formatted'] = dol_print_phone($substitution['phone_mobile'], $substitution['country_code'], 0, 0, '', ' ');
-						}
-					}
-				}
-			}
-		}
-		$substitutions = array_merge($substitutions, $contacts);
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutions($object, $outputlangs, $typescontact));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
-			'lines' => [],
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'labelpaymentconditions' => $label_payment_conditions,
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		$linesarray = [];
-		foreach ($object->lines as $key => $line) {
-			$subtotal_ht += $line->total_ht;
-			$subtotal_ttc += $line->total_ttc;
-			if ($line->special_code == 104777 && $line->qty == 99) {
-				$line->total_ht = $subtotal_ht;
-				$line->total_ttc = $subtotal_ttc;
-				$subtotal_ht = 0;
-				$subtotal_ttc = 0;
-			}
-			$linearray = getEachVarObject($line, $outputlangs, 0, 'line');
-			$linesarray[$key] = $linearray['line'];
-			$linesarray[$key]['linenumber'] = $linenumber;
-			$linesarray[$key]['subtotal_ht'] = $subtotal_ht;
-			if ($line->fk_product > 0) {
-				$product = new Product($this->db);
-				$product->fetch($line->fk_product);
-				$linesarray[$key]['product'] = getEachVarObject($product, $outputlangs)['object'];
-				$cat = new Categorie($this->db);
-				$linesarray[$key]['categories'] = $cat->getListForItem($line->fk_product, 'product');
-				$linesarray[$key]['photos'] = [];
-				$pdir = [];
-				if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
-					$pdir[0] = get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . "/photos/";
-					$pdir[1] = get_exdir(0, 0, 0, 0, $product, 'product') . dol_sanitizeFileName($product->ref) . '/';
-				} else {
-					$pdir[0] = get_exdir(0, 0, 0, 0, $product, 'product'); // default
-					$pdir[1] = get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . "/photos/"; // alternative
-				}
-				foreach ($pdir as $midir) {
-					if ($conf->entity != $product->entity) {
-						$dir = $conf->product->multidir_output[$product->entity] . '/' . $midir; //Check repertories of current entities
-					} else {
-						$dir = $conf->product->dir_output . '/' . $midir; //Check repertory of the current product
-					}
-					foreach ($product->liste_photos($dir, 1) as $photokey => $obj) {
-						// if (!getDolGlobalInt('CAT_HIGH_QUALITY_IMAGES')) {		// If CAT_HIGH_QUALITY_IMAGES not defined, we use thumb if defined and then original photo
-						// 	if ($obj['photo_vignette']) {
-						// 		$filename = $obj['photo_vignette'];
-						// 	} else {
-						// 		$filename = $obj['photo'];
-						// 	}
-						// } else {
-						$filename = $obj['photo'];
-						// }
 
-						$linesarray[$key]['photos'][] = $dir . $filename;
-					}
-				}
-			}
+		// Propale: extended lines (categories, photos), recursive=false
+		$substitutions = array_merge($substitutions, ['lines' => $this->buildExtendedLinesSubstitutions($object, $outputlangs, false)]);
 
-			// $substitutions['lines'][$key] = [
-			// 	'linenumber' => $linenumber,
-			// 	'qty' => $line->qty,
-			// 	'ref' => $line->product_ref,
-			// 	'label' => $line->label,
-			// 	'description' => $line->desc,
-			// 	'product_label' => $line->product_label,
-			// 	'product_description' => $line->product_desc,
-			// 	'subprice' => $line->subprice,
-			// 	'total_ht' => $line->total_ht,
-			// 	'total_ttc' => $line->total_ttc,
-			// 	'vatrate' => $line->tva_tx,
-			// 	'special_code' => $line->special_code,
-			// 	'product_type' => $line->product_type,
-			// 	'line_options' => [],
-			// 	'product_options' => [],
-			// ];
-			if (empty($line->special_code)) {
-				$linenumber++;
-			}
-		}
-		$substitutions = array_merge($substitutions, ['lines' => $linesarray]);
-
-		$substitutions['parameters'] = [
-			'hidedetails' => $hidedetails,
-			'hidedesc' => $hidedesc,
-			'hideref' => $hideref,
-		];
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
 		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
 			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
 		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -552,30 +244,22 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
-		$defaultConfig = (new Mpdf\Config\ConfigVariables())->getDefaults();
-		$fontDirs = $defaultConfig['fontDir'];
 
-		$defaultFontConfig = (new Mpdf\Config\FontVariables())->getDefaults();
-		$fontData = $defaultFontConfig['fontdata'];
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
-			'fontDir' => array_merge($fontDirs, [DOL_DATA_ROOT . '/easydocgenerator/fonts']),
 			'format' => $this->format,
-			'margin_left' => $this->marge_gauche,
-			'margin_right' => $this->marge_droite,
-			'margin_top' => $this->marge_haute,
-			'margin_bottom' => $this->marge_basse,
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_left' => getDolGlobalInt('EASYDOC_PDF_MARGIN_LEFT', 10),
+			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
+			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
+			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
-		$mpdf->SetProtection(['copy', 'print', 'modify', 'annot-forms', 'fill-forms', 'extract', 'assemble', 'print-highres']);
-		// $mpdf->SetProtection([]); // deny all
+		$mpdf->SetProtection(['print']);
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("PdfCommercialProposalTitle") . " " . $outputlangs->convToOutputCharset($object->thirdparty->name));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('PdfCommercialProposalTitle') . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name));
 		$text = getDolGlobalString('PROPALE_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -584,77 +268,49 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 		$mpdf->showWatermarkText = ($object->status == Propal::STATUS_DRAFT && getDolGlobalString('PROPALE_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfCommercialProposalTitle'));
 		$mpdf->WriteHTML($html);
 
-		//If propal merge product PDF is active
+		// Propale-specific: merge product PDFs when PRODUIT_PDF_MERGE_PROPAL is active
 		if (getDolGlobalString('PRODUIT_PDF_MERGE_PROPAL')) {
 			require_once DOL_DOCUMENT_ROOT . '/product/class/propalmergepdfproduct.class.php';
 			$already_merged = [];
 			foreach ($object->lines as $line) {
 				if (!empty($line->fk_product) && !(in_array($line->fk_product, $already_merged))) {
-					// Find the desired PDF
 					$filetomerge = new Propalmergepdfproduct($this->db);
-
 					if (getDolGlobalInt('MAIN_MULTILANGS')) {
 						$filetomerge->fetch_by_product($line->fk_product, $outputlangs->defaultlang);
 					} else {
 						$filetomerge->fetch_by_product($line->fk_product);
 					}
-
 					$already_merged[] = $line->fk_product;
-
 					$product = new Product($this->db);
 					$product->fetch($line->fk_product);
-
-					if ($product->entity != $conf->entity) {
-						$entity_product_file = $product->entity;
-					} else {
-						$entity_product_file = $conf->entity;
-					}
-					// If PDF is selected and file is not empty
+					$entity_product_file = ($product->entity != $conf->entity) ? $product->entity : $conf->entity;
 					if (count($filetomerge->lines) > 0) {
 						foreach ($filetomerge->lines as $linefile) {
 							if (!empty($linefile->id) && !empty($linefile->file_name)) {
 								if (getDolGlobalInt('PRODUCT_USE_OLD_PATH_FOR_PHOTO')) {
-									if (isModEnabled("product")) {
-										$filetomerge_dir = $conf->product->multidir_output[$entity_product_file] . '/' . get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . "/photos";
-									} elseif (isModEnabled("service")) {
-										$filetomerge_dir = $conf->service->multidir_output[$entity_product_file] . '/' . get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . "/photos";
-									}
+									$filetomerge_dir = isModEnabled('product')
+										? $conf->product->multidir_output[$entity_product_file] . '/' . get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . '/photos'
+										: $conf->service->multidir_output[$entity_product_file] . '/' . get_exdir($product->id, 2, 0, 0, $product, 'product') . $product->id . '/photos';
 								} else {
-									if (isModEnabled("product")) {
-										$filetomerge_dir = $conf->product->multidir_output[$entity_product_file] . '/' . get_exdir(0, 0, 0, 0, $product, 'product');
-									} elseif (isModEnabled("service")) {
-										$filetomerge_dir = $conf->service->multidir_output[$entity_product_file] . '/' . get_exdir(0, 0, 0, 0, $product, 'product');
-									}
+									$filetomerge_dir = isModEnabled('product')
+										? $conf->product->multidir_output[$entity_product_file] . '/' . get_exdir(0, 0, 0, 0, $product, 'product')
+										: $conf->service->multidir_output[$entity_product_file] . '/' . get_exdir(0, 0, 0, 0, $product, 'product');
 								}
-
 								dol_syslog(get_class($this) . ':: upload_dir=' . $filetomerge_dir, LOG_DEBUG);
-
 								$infile = $filetomerge_dir . $linefile->file_name;
 								if (file_exists($infile) && is_readable($infile)) {
 									try {
 										$pagecount = $mpdf->setSourceFile($infile);
-										// stop adding header on every page
 										$mpdf->SetHeader();
 										$mpdf->Bookmark($linefile->file_name);
-										// This PDF document probably uses a compression technique which is not supported by the free parser shipped with FPDI
-										// Alternatively the document you're trying to import has to be resaved without the use of compressed cross-reference streams
-										// and objects by an external programm (e.g. by lowering the PDF version to 1.4).
 										for ($i = 1; $i <= $pagecount; $i++) {
 											$tplIdx = $mpdf->importPage($i);
 											if ($tplIdx !== false) {
 												$s = $mpdf->getTemplatesize($tplIdx);
-												// array (size=5)
-												//   'width' => float 210.00155555556
-												//   'height' => float 296.99655555556
-												//   0 => float 210.00155555556
-												//   1 => float 296.99655555556
-												//   'orientation' => string 'P' (length=1)
 												$mpdf->AddPage($s['height'] > $s['width'] ? 'P' : 'L');
 												$mpdf->useTemplate($tplIdx);
 											} else {
@@ -673,38 +329,6 @@ class doc_easydoc_propale_html extends ModelePDFPropales
 			}
 		}
 
-		$dir = $conf->propal->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$parameters = [
-			'file' => $file,
-			'object' => $object,
-			'outputlangs' => $outputlangs,
-			'outputlangsbis' => $outputlangsbis,
-		];
-		// Note that $action and $object may have been modified by some hooks
-		$hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->propal->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/stock/doc/doc_easydoc_stock_html.modules.php
+++ b/core/modules/stock/doc/doc_easydoc_stock_html.modules.php
@@ -27,8 +27,6 @@
  *	\brief      File of class to build PDF documents for stocks
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/stock/modules_stock.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
@@ -37,6 +35,7 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -45,34 +44,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_stock_html extends ModelePDFStock
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'STOCK_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'stocks';
 		$this->update_main_doc_field = 0;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -82,124 +74,20 @@ class doc_easydoc_stock_html extends ModelePDFStock
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option STOCK_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="' . $this->scandir . '">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		$texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		$texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=stocks/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$text .= ' &nbsp; <a class="reposition" href="' . $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=' . urlencode($this->scandir) . '&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name'])) . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . urlencode($this->scandir) . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
@@ -217,10 +105,10 @@ class doc_easydoc_stock_html extends ModelePDFStock
 	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
 	{
 		// phpcs:enable
-		global $user, $langs, $conf, $mysoc, $hookmanager;
+		global $action, $user, $langs, $conf, $mysoc, $hookmanager;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_stock_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_stock_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -229,7 +117,8 @@ class doc_easydoc_stock_html extends ModelePDFStock
 		if (!is_object($outputlangs)) {
 			$outputlangs = $langs;
 		}
-		$outputlangs->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'stocks', 'easydocgenerator@easydocgenerator']);
+		$langfiles = ['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks', 'stocks', 'easydocgenerator@easydocgenerator'];
+		$outputlangs->loadLangs($langfiles);
 
 		global $outputlangsbis;
 		$outputlangsbis = null;
@@ -239,80 +128,23 @@ class doc_easydoc_stock_html extends ModelePDFStock
 			$outputlangsbis->loadLangs(['main', 'dict', 'companies', 'bills', 'products', 'orders', 'deliveries', 'banks']);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs];
-		global $action;
-		$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : DOL_DATA_ROOT . '/easydocgenerator/temp',
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			return price($price, 0);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -322,171 +154,77 @@ class doc_easydoc_stock_html extends ModelePDFStock
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if ($this->emetteur->logo) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
-		// If CUSTOMER contact defined on stock, we use it
-		$usecontact = false;
-		$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
-		if (count($arrayidcontact) > 0) {
-			$usecontact = true;
-			$result = $object->fetch_contact($arrayidcontact[0]);
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
 
-		// Recipient name
-		$contactobject = null;
-		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
-				$object->contact->fetch_thirdparty();
-				$socobject = $object->contact->thirdparty;
-				$contactobject = $object->contact;
-			} else {
-				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
-				$contactobject = $object->contact;
-			}
-		} else {
-			$socobject = $object->thirdparty;
-		}
-
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
-
-		// Call the ODTSubstitution hook
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$substitutionarray];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'STOCK_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
-
-		// thirdparty
-		if (!empty($object->thirdparty)) {
-			$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-			$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-			$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-			$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
-		}
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
 		];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				$contacts = [];
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$contact->fetch($idc);
-					$contacts[] = $contact;
-				}
-				$substitutions = array_merge($substitutions, getEachVarObject($contacts, $outputlangs, 1, strtolower($type) . '_' . $key));
-			}
-		}
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutionsSimple($object, $outputlangs, $typescontact));
 
+		// Stock-specific: lines built from SQL warehouse inventory
 		$totalunit = 0;
-		$totalvalue = 0;
-		$totalvaluesell = 0;
+		$totalunique = 0;
 		$substitutions['lines'] = [];
-		$sortfield = 'p.ref';
-		$sortorder = 'ASC';
+		$sql = 'SELECT p.rowid as rowid, p.ref, p.label as label, p.tobatch, p.fk_product_type as type, p.pmp as ppmp, p.price, p.price_ttc, p.entity,';
+		$sql .= ' ps.reel as real_qty';
+		$sql .= ' FROM ' . MAIN_DB_PREFIX . 'product_stock as ps, ' . MAIN_DB_PREFIX . 'product as p';
+		$sql .= ' WHERE ps.fk_product = p.rowid';
+		$sql .= ' AND ps.reel <> 0';
+		$sql .= ' AND ps.fk_entrepot = ' . ((int) $object->id);
+		$sql .= $this->db->order('p.ref', 'ASC');
 
-		$sql = "SELECT p.rowid as rowid, p.ref, p.label as label, p.tobatch, p.fk_product_type as type, p.pmp as ppmp, p.price, p.price_ttc, p.entity,";
-		$sql .= " ps.reel as real_qty";
-		$sql .= " FROM " . MAIN_DB_PREFIX . "product_stock as ps, " . MAIN_DB_PREFIX . "product as p";
-		$sql .= " WHERE ps.fk_product = p.rowid";
-		$sql .= " AND ps.reel <> 0"; // We do not show if stock is 0 (no product in this warehouse)
-		$sql .= " AND ps.fk_entrepot = " . ((int) $object->id);
-		$sql .= $this->db->order($sortfield, $sortorder);
-
-		//dol_syslog('List products', LOG_DEBUG);
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$num = $this->db->num_rows($resql);
 			$totalunique = $num;
-			$i = 0;
 			for ($i = 0; $i < $num; $i++) {
 				$objp = $this->db->fetch_array($resql);
 				$substitutions['lines'][] = $objp;
 				$totalunit += (int) $objp['real_qty'];
 			}
 		}
-		// other
+
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 			'totalunit' => $totalunit,
 			'totalunique' => $totalunique,
 		]);
 
-		$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
+		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
+			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
+		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -496,7 +234,7 @@ class doc_easydoc_stock_html extends ModelePDFStock
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -504,15 +242,14 @@ class doc_easydoc_stock_html extends ModelePDFStock
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("PdfStockTitle"));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('PdfStockTitle'));
 		$text = getDolGlobalString('STOCK_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -521,35 +258,10 @@ class doc_easydoc_stock_html extends ModelePDFStock
 		$mpdf->showWatermarkText = ($object->status == Entrepot::STATUS_CLOSED && getDolGlobalString('STOCK_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfOrderTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->stock->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->stock->multidir_output[$object->entity], $srctemplatepath);
 	}
 }

--- a/core/modules/ticket/doc/doc_easydoc_ticket_html.modules.php
+++ b/core/modules/ticket/doc/doc_easydoc_ticket_html.modules.php
@@ -27,16 +27,14 @@
  *	\brief      File of class to build PDF documents for tickets
  */
 
-use NumberToWords\NumberToWords;
-
 require_once DOL_DOCUMENT_ROOT . '/core/modules/ticket/modules_ticket.php';
-require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/company.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/functions2.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/doc.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/pdf.lib.php';
 dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
+dol_include_once('/easydocgenerator/class/EasyDocHtmlTrait.php');
 
 // phpcs:disable
 /**
@@ -45,34 +43,27 @@ dol_include_once('/easydocgenerator/lib/easydocgenerator.lib.php');
 class doc_easydoc_ticket_html extends ModelePDFTicket
 {
 	// phpcs:enable
-	/**
-	 * Dolibarr version of the loaded document
-	 * @var string
-	 */
+	use EasyDocHtmlTrait;
+
+	/** @var string Dolibarr version of the loaded document */
 	public $version = 'dolibarr';
 
-
 	/**
-	 *	Constructor
-	 *
-	 *  @param		DoliDB		$db      Database handler
+	 * @param DoliDB $db Database handler
 	 */
 	public function __construct($db)
 	{
 		global $langs, $mysoc;
 
-		// Load translation files required by the page
 		$langs->loadLangs(['main', 'companies', 'easydocgenerator@easydocgenerator']);
 
 		$this->db = $db;
-		$this->name = "Easydoc templates";
-		$this->description = $langs->trans("DocumentModelEasydocgeneratorTemplate");
-		// Name of constant that is used to save list of directories to scan
+		$this->name = 'Easydoc templates';
+		$this->description = $langs->trans('DocumentModelEasydocgeneratorTemplate');
 		$this->scandir = 'TICKET_ADDON_EASYDOC_TEMPLATES_PATH';
-		// Save the name of generated file as the main doc when generating a doc with this template
+		$this->templateFileSection = 'tickets';
 		$this->update_main_doc_field = 1;
 
-		// Page size for A4 format
 		$this->type = 'pdf';
 		$this->page_largeur = 210;
 		$this->page_hauteur = 297;
@@ -82,131 +73,27 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 		$this->marge_haute = 0;
 		$this->marge_basse = 0;
 
-		$this->option_logo = 1; // Display logo
-		$this->option_tva = 0; // Manage the vat option TICKET_TVAOPTION
-		$this->option_modereg = 0; // Display payment mode
-		$this->option_condreg = 0; // Display payment terms
-		$this->option_multilang = 1; // Available in several languages
-		$this->option_escompte = 0; // Displays if there has been a discount
-		$this->option_credit_note = 0; // Support credit notes
-		$this->option_freetext = 1; // Support add of a personalised text
-		$this->option_draft_watermark = 0; // Support add of a watermark on drafts
+		$this->option_logo = 1;
+		$this->option_tva = 0;
+		$this->option_modereg = 0;
+		$this->option_condreg = 0;
+		$this->option_multilang = 1;
+		$this->option_escompte = 0;
+		$this->option_credit_note = 0;
+		$this->option_freetext = 1;
+		$this->option_draft_watermark = 0;
 
-		// Get source company
 		$this->emetteur = $mysoc;
 		if (!$this->emetteur->country_code) {
-			$this->emetteur->country_code = substr($langs->defaultlang, -2); // By default if not defined
+			$this->emetteur->country_code = substr($langs->defaultlang, -2);
 		}
-	}
-
-
-	/**
-	 *	Return description of a module
-	 *
-	 *	@param	Translate	$langs      Lang object to use for output
-	 *	@return string       			Description
-	 */
-	public function info($langs)
-	{
-		global $langs;
-
-		// Load translation files required by the page
-		$langs->loadLangs(["errors", "companies", "easydocgenerator@easydocgenerator"]);
-
-		$form = new Form($this->db);
-
-		$text = $this->description . ".<br>\n";
-		$text .= '<form action="' . $_SERVER["PHP_SELF"] . '" method="POST" enctype="multipart/form-data">';
-		$text .= '<input type="hidden" name="token" value="' . newToken() . '">';
-		$text .= '<input type="hidden" name="page_y" value="">';
-		$text .= '<input type="hidden" name="action" value="setModuleOptions">';
-		$text .= '<input type="hidden" name="param1" value="TICKET_ADDON_EASYDOC_TEMPLATES_PATH">';
-		$text .= '<table class="nobordernopadding" width="100%">';
-
-		// List of directories area
-		$text .= '<tr><td>';
-		$texttitle = $langs->trans("ListOfDirectoriesForHtmlTemplates");
-		$listofdir = explode(',', preg_replace('/[\r\n]+/', ',', trim(getDolGlobalString($this->scandir))));
-		$listoffiles = [];
-		foreach ($listofdir as $key => $tmpdir) {
-			$tmpdir = trim($tmpdir);
-			$tmpdir = preg_replace('/DOL_DATA_ROOT/', DOL_DATA_ROOT, $tmpdir);
-			if (!$tmpdir) {
-				unset($listofdir[$key]);
-				continue;
-			}
-			if (!is_dir($tmpdir)) {
-				$texttitle .= img_warning($langs->trans("ErrorDirNotFound", $tmpdir), 0);
-			} else {
-				$tmpfiles = dol_dir_list($tmpdir, 'files', 0, '\.(twig)');
-				if (count($tmpfiles)) {
-					$listoffiles = array_merge($listoffiles, $tmpfiles);
-				}
-			}
-		}
-		$texthelp = $langs->trans("ListOfDirectoriesForModelGenHTML");
-		$texthelp .= '<br><br><span class="opacitymedium">' . $langs->trans("ExampleOfDirectoriesForModelGen") . '</span>';
-		// Add list of substitution keys
-		$texthelp .= '<br>' . $langs->trans("FollowingSubstitutionKeysCanBeUsed") . '<br>';
-		$texthelp .= $langs->transnoentitiesnoconv("FullListOnOnlineDocumentation"); // This contains an url, we don't modify it
-
-		$text .= $form->textwithpicto($texttitle, $texthelp, 1, 'help', '', 1, 3, $this->name);
-		$text .= '<div><div style="display: inline-block; min-width: 100px; vertical-align: middle;">';
-		$text .= '<textarea class="flat" cols="60" name="value1">';
-		$text .= getDolGlobalString($this->scandir);
-		$text .= '</textarea>';
-		$text .= '</div><div style="display: inline-block; vertical-align: middle;">';
-		$text .= '<input type="submit" class="button button-edit reposition smallpaddingimp" name="modify" value="' . dol_escape_htmltag($langs->trans("Modify")) . '">';
-		$text .= '<br></div></div>';
-
-		// Scan directories
-		$nbofiles = count($listoffiles);
-		if (getDolGlobalString($this->scandir)) {
-			$text .= $langs->trans("NumberOfModelHTMLFilesFound") . ': <b>';
-			//$text.=$nbofiles?'<a id="a_'.get_class($this).'" href="#">':'';
-			$text .= count($listoffiles);
-			//$text.=$nbofiles?'</a>':'';
-			$text .= '</b>';
-		}
-
-		if ($nbofiles) {
-			$text .= '<div id="div_' . get_class($this) . '" class="hiddenx">';
-			// Show list of found files
-			foreach ($listoffiles as $file) {
-				$text .= '- ' . $file['name'] . ' <a href="' . DOL_URL_ROOT . '/document.php?modulepart=doctemplates&file=tickets/' . urlencode(basename($file['name'])) . '">' . img_picto('', 'listlight') . '</a>';
-				$text .= ' &nbsp; <a class="reposition" href="' . $_SERVER["PHP_SELF"] . '?modulepart=doctemplates&keyforuploaddir=TICKET_ADDON_EASYDOC_TEMPLATES_PATH&action=deletefile&token=' . newToken() . '&file=' . urlencode(basename($file['name'])) . '">' . img_picto('', 'delete') . '</a>';
-				$text .= '<br>';
-			}
-			$text .= '</div>';
-		}
-		// Add input to upload a new template file.
-		$text .= '<div>' . $langs->trans("UploadNewTemplate");
-		$maxfilesizearray = getMaxFileSizeArray();
-		$maxmin = $maxfilesizearray['maxmin'];
-		if ($maxmin > 0) {
-			// MAX_FILE_SIZE must precede the field type=file
-			$text .= '<input type="hidden" name="MAX_FILE_SIZE" value="' . ($maxmin * 1024) . '">';
-		}
-		$text .= ' <input type="file" name="uploadfile">';
-		$text .= '<input type="hidden" value="' . $this->scandir . '" name="keyforuploaddir">';
-		$text .= '<input type="submit" class="button reposition smallpaddingimp" value="' . dol_escape_htmltag($langs->trans("Upload")) . '" name="upload">';
-		$text .= '</div>';
-
-		$text .= '</td>';
-
-		$text .= '</tr>';
-
-		$text .= '</table>';
-		$text .= '</form>';
-
-		return $text;
 	}
 
 	// phpcs:disable
 	/**
 	 *  Function to build a document on disk using the generic odt module.
 	 *
-	 *	@param		Ticket	$object				Object source to build document
+	 *	@param		Ticket		$object				Object source to build document
 	 *	@param		Translate	$outputlangs		Lang output object
 	 * 	@param		string		$srctemplatepath	Full path of source filename for generator using a template file
 	 *  @param		int			$hidedetails		Do not show line details
@@ -217,10 +104,10 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 	public function write_file($object, $outputlangs, $srctemplatepath = '', $hidedetails = 0, $hidedesc = 0, $hideref = 0)
 	{
 		// phpcs:enable
-		global $user, $langs, $conf, $mysoc, $hookmanager;
+		global $action, $user, $langs, $conf, $mysoc, $hookmanager;
 
 		if (empty($srctemplatepath)) {
-			dol_syslog("doc_easydoc_ticket_html::write_file parameter srctemplatepath empty", LOG_WARNING);
+			dol_syslog('doc_easydoc_ticket_html::write_file parameter srctemplatepath empty', LOG_WARNING);
 			return -1;
 		}
 
@@ -240,80 +127,23 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 			$outputlangsbis->loadLangs($langfiles);
 		}
 
-		// add linked objects to note_public
 		$linkedObjects = pdf_getLinkedObjects($object, $outputlangs);
-
-
-		$sav_charset_output = $outputlangs->charset_output;
 		$outputlangs->charset_output = 'UTF-8';
-
-		// For backward compatibility with FPDF, force output charset to ISO, because FPDF expect text to be encoded in ISO
 		if (getDolGlobalInt('MAIN_USE_FPDF')) {
-			// test it to crash...
 			$outputlangs->charset_output = 'ISO-8859-1';
 		}
 
 		$currency = !empty($object->multicurrency_code) ? $object->multicurrency_code : $conf->currency;
 
-		// Add pdfgeneration hook
 		if (!is_object($hookmanager)) {
 			include_once DOL_DOCUMENT_ROOT . '/core/class/hookmanager.class.php';
 			$hookmanager = new HookManager($this->db);
 		}
 		$hookmanager->initHooks(['pdfgeneration']);
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs];
-		global $action;
-		$reshook = $hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
+		$hookmanager->executeHooks('beforePDFCreation', $parameters, $object, $action);
 
-		require dol_buildpath('easydocgenerator/vendor/autoload.php');
-
-		$loader = new \Twig\Loader\FilesystemLoader(dirname($srctemplatepath));
-		$twig = new \Twig\Environment($loader, [
-			// developer mode unactive caching
-			'cache' => getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE') ? false : DOL_DATA_ROOT . '/easydocgenerator/temp',
-			'autoescape' => false,
-		]);
-		// create twig function which translate with $outpulangs->trans()
-		$function = new \Twig\TwigFunction('trans', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangs, $langs;
-			if (!is_object($outputlangs)) {
-				$outputlangs = $langs;
-			}
-			return $outputlangs->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which translate with $outpulangsbis->trans()
-		$function = new \Twig\TwigFunction('transbis', function ($value, $param1 = '', $param2 = '', $param3 = '') {
-			global $outputlangsbis, $langs;
-			if (!is_object($outputlangsbis)) {
-				$outputlangsbis = $langs;
-			}
-			return $outputlangsbis->trans($value, $param1, $param2, $param3);
-		});
-		$twig->addFunction($function);
-		// create twig function which returns getDolGlobalString(
-		$function = new \Twig\TwigFunction('getDolGlobalString', function ($value, $default = '') {
-			return getDolGlobalString($value, $default);
-		});
-		$twig->addFunction($function);
-		// create twig function which return date formatted
-		$function = new \Twig\TwigFunction('date', function ($time, $format = '') {
-			return dol_print_date($time, $format);
-		});
-		$twig->addFunction($function);
-		// create twig function which return price formatted
-		$function = new \Twig\TwigFunction('price', function ($price) {
-			return price($price, 0);
-		});
-		$twig->addFunction($function);
-		// create twig function which return number to words
-		$function = new \Twig\TwigFunction('numbertowords', function ($number, $currency, $language) {
-			$numbertow = new NumberToWords();
-			$currencyTransformer = $numbertow->getCurrencyTransformer($language);
-			return $currencyTransformer->toWords($number * 100, $currency);
-		});
-		$twig->addFunction($function);
-		// Load template
+		$twig = $this->buildTwigEnvironment($srctemplatepath);
 		try {
 			$template = $twig->load(basename($srctemplatepath));
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -323,130 +153,38 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 			$this->errors = $e->getMessage();
 			return -1;
 		}
-		$logo = '';
-		if ($this->emetteur->logo) {
-			$logodir = $conf->mycompany->dir_output;
-			if (!getDolGlobalInt('MAIN_PDF_USE_LARGE_LOGO')) {
-				$logo = $logodir . '/logos/thumbs/' . $this->emetteur->logo_small;
-			} else {
-				$logo = $logodir . '/logos/' . $this->emetteur->logo;
-			}
-		}
-		$langtocountryflag = [
-			'ar_AR' => '',
-			'ca_ES' => 'catalonia',
-			'da_DA' => 'dk',
-			'fr_CA' => 'mq',
-			'sv_SV' => 'se',
-			'sw_SW' => 'unknown',
-			'AQ' => 'unknown',
-			'CW' => 'unknown',
-			'IM' => 'unknown',
-			'JE' => 'unknown',
-			'MF' => 'unknown',
-			'BL' => 'unknown',
-			'SX' => 'unknown'
-		];
 
-		if (isset($langtocountryflag[$mysoc->country_code])) {
-			$flagImage = $langtocountryflag[$mysoc->country_code];
-		} else {
-			$tmparray = explode('_', $mysoc->country_code);
-			$flagImage = empty($tmparray[1]) ? $tmparray[0] : $tmparray[1];
-		}
-		// If CUSTOMER contact defined on ticket, we use it
-		$usecontact = false;
-		$arrayidcontact = $object->getIdContact('external', 'CUSTOMER');
-		if (count($arrayidcontact) > 0) {
-			$usecontact = true;
-			$result = $object->fetch_contact($arrayidcontact[0]);
-		}
+		$logo = $this->buildLogo();
+		$flagImage = $this->buildFlagImage();
 
-		// Recipient name
-		$contactobject = null;
-		if (!empty($usecontact)) {
-			// We can use the company of contact instead of thirdparty company
-			if ($object->contact->socid != $object->thirdparty->id && (!isset($conf->global->MAIN_USE_COMPANY_NAME_OF_CONTACT) || getDolGlobalString('MAIN_USE_COMPANY_NAME_OF_CONTACT'))) {
-				$object->contact->fetch_thirdparty();
-				$socobject = $object->contact->thirdparty;
-				$contactobject = $object->contact;
-			} else {
-				$socobject = $object->thirdparty;
-				// if we have a CUSTOMER contact and we don't use it as thirdparty recipient we store the contact object for later use
-				$contactobject = $object->contact;
-			}
-		} else {
-			$socobject = $object->thirdparty;
-		}
-
-		// Make substitution
 		$substitutionarray = [
 			'__FROM_NAME__' => $this->emetteur->name,
 			'__FROM_EMAIL__' => $this->emetteur->email,
 			'__TOTAL_TTC__' => $object->total_ttc,
 			'__TOTAL_HT__' => $object->total_ht,
-			'__TOTAL_VAT__' => $object->total_tva
+			'__TOTAL_VAT__' => $object->total_tva,
 		];
 		complete_substitutions_array($substitutionarray, $langs, $object);
 		$substitutionarray = array_merge(getCommonSubstitutionArray($outputlangs, 0, null, $object), $substitutionarray);
-
-		// Call the ODTSubstitution hook
 		$parameters = ['object' => $object, 'outputlangs' => $outputlangs, 'substitutionarray' => &$substitutionarray];
-		$reshook = $hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
+		$hookmanager->executeHooks('ODTSubstitution', $parameters, $this, $action);
 
-		// Line of free text
-		$newfreetext = '';
 		$paramfreetext = 'TICKET_FREE_TEXT';
+		$newfreetext = '';
 		if (!empty($conf->global->$paramfreetext)) {
 			$newfreetext = make_substitutions(getDolGlobalString($paramfreetext), $substitutionarray);
 		}
-		// mysoc
-		$substitutions = getEachVarObject($mysoc, $outputlangs, 1, 'mysoc');
-		$substitutions['mysoc']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($flagImage) . '.png';
-		$substitutions['mysoc']['phone_formatted'] = dol_print_phone($mysoc->phone, $mysoc->country_code, 0, 0, '', ' ');
-		$substitutions['mysoc']['fax_formatted'] = dol_print_phone($mysoc->fax, $mysoc->country_code, 0, 0, '', ' ');
 
-		// object
+		$substitutions = $this->buildMysocSubstitutions($outputlangs, $flagImage);
 		$substitutions = array_merge($substitutions, getEachVarObject($object, $outputlangs, 0));
-
-		// thirdparty
-		$substitutions = array_merge($substitutions, getEachVarObject($object->thirdparty, $outputlangs, 1, 'thirdparty'));
-		$substitutions['thirdparty']['flag'] = DOL_DOCUMENT_ROOT . '/theme/common/flags/' . strtolower($object->thirdparty->country_code) . '.png';
-		$substitutions['thirdparty']['phone_formatted'] = dol_print_phone($object->thirdparty->phone, $object->thirdparty->country_code, 0, 0, '', ' ');
-		$substitutions['thirdparty']['fax_formatted'] = dol_print_phone($object->thirdparty->fax, $object->thirdparty->country_code, 0, 0, '', ' ');
+		$substitutions = array_merge($substitutions, $this->buildThirdpartySubstitutions($object, $outputlangs));
 
 		$typescontact = [
-			'external' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
-			'internal' => [
-				'BILLING',
-				'SHIPPING',
-				'SALESREPFOLL',
-				'CUSTOMER',
-			],
+			'external' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
+			'internal' => ['BILLING', 'SHIPPING', 'SALESREPFOLL', 'CUSTOMER'],
 		];
-		foreach ($typescontact as $key => $value) {
-			foreach ($value as $type) {
-				$arrayidcontact = $object->getIdContact($key, $type);
-				$contacts = [];
-				foreach ($arrayidcontact as $idc) {
-					if ($key == 'external') {
-						$contact = new Contact($this->db);
-					} else {
-						$contact = new User($this->db);
-					}
-					$contact->fetch($idc);
-					$contacts[] = $contact;
-				}
-				$substitutions = array_merge($substitutions, getEachVarObject($contacts, $outputlangs, 1, strtolower($type) . '_' . $key));
-			}
-		}
+		$substitutions = array_merge($substitutions, $this->buildContactsSubstitutionsSimple($object, $outputlangs, $typescontact));
 
-		// other
 		$substitutions = array_merge($substitutions, [
 			'logo' => $logo,
 			'freetext' => $newfreetext,
@@ -454,45 +192,14 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 			'linkedObjects' => $linkedObjects,
 			'footerinfo' => getPdfPagefoot($outputlangs, $paramfreetext, $mysoc, $object),
 			'currency' => $currency,
-			'currencyinfo' => $outputlangs->trans("AmountInCurrency", $outputlangs->trans("Currency" . $currency)),
+			'currencyinfo' => $outputlangs->trans('AmountInCurrency', $outputlangs->trans('Currency' . $currency)),
 		]);
-		// var_dump($substitutions);
-		$subtotal_ht = 0;
-		$subtotal_ttc = 0;
-		$linenumber = 1;
-		// foreach ($object->lines as $key => $line) {
-		// 	$subtotal_ht += $line->total_ht;
-		// 	$subtotal_ttc += $line->total_ttc;
-		// 	if ($line->special_code == 104777 && $line->qty == 99) {
-		// 		$line->total_ht = $subtotal_ht;
-		// 		$line->total_ttc = $subtotal_ttc;
-		// 		$subtotal_ht = 0;
-		// 		$subtotal_ttc = 0;
-		// 	}
-		// 	$substitutions['lines'][$key] = [
-		// 		'linenumber' => $linenumber,
-		// 		'qty' => $line->qty,
-		// 		'ref' => $line->product_ref,
-		// 		'label' => $line->label,
-		// 		'description' => $line->desc,
-		// 		'product_label' => $line->product_label,
-		// 		'product_description' => $line->product_desc,
-		// 		'subprice' => price($line->subprice),
-		// 		'total_ht' => price($line->total_ht),
-		// 		'total_ttc' => price($line->total_ttc),
-		// 		'vatrate' => price($line->tva_tx) . '%',
-		// 		'special_code' => $line->special_code,
-		// 		'product_type' => $line->product_type,
-		// 		'line_options' => [],
-		// 		'product_options' => [],
-		// 	];
-		// 	if (empty($line->special_code)) {
-		// 		$linenumber++;
-		// 	}
-		// }
 
-		// var_dump($substitutions);
-		$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
+		$substitutions['parameters'] = ['hidedetails' => $hidedetails, 'hidedesc' => $hidedesc, 'hideref' => $hideref];
+		if (getDolGlobalInt('EASYDOCGENERATOR_ENABLE_DEVELOPPER_MODE')) {
+			$substitutions['debug'] = '<pre>' . print_r($substitutions, true) . '</pre>';
+		}
+
 		try {
 			$html = $template->render($substitutions);
 		} catch (\Twig\Error\SyntaxError $e) {
@@ -502,7 +209,7 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 			$this->errors[] = $e->getMessage();
 			return -1;
 		}
-		// print $html;
+
 		$mpdf = new \Mpdf\Mpdf([
 			'tempDir' => DOL_DATA_ROOT . '/easydocgenerator/temp',
 			'format' => $this->format,
@@ -510,15 +217,14 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 			'margin_right' => getDolGlobalInt('EASYDOC_PDF_MARGIN_RIGHT', 10),
 			'margin_top' => getDolGlobalInt('EASYDOC_PDF_MARGIN_TOP', 48),
 			'margin_bottom' => getDolGlobalInt('EASYDOC_PDF_MARGIN_BOTTOM', 25),
-			'margin_header' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
-			'margin_footer' =>  getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
+			'margin_header' => getDolGlobalInt('EASYDOC_PDF_MARGIN_HEADER', 10),
+			'margin_footer' => getDolGlobalInt('EASYDOC_PDF_MARGIN_FOOTER', 10),
 		]);
 		$mpdf->SetProtection(['print']);
 		$mpdf->SetTitle($outputlangs->convToOutputCharset($object->ref));
 		$mpdf->SetCreator('Dolibarr ' . DOL_VERSION);
 		$mpdf->SetAuthor($outputlangs->convToOutputCharset($user->getFullName($outputlangs)));
-		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . " " . $outputlangs->transnoentities("PdfTicketTitle") . " " . $outputlangs->convToOutputCharset($object->thirdparty->name));
-		// Watermark
+		$mpdf->SetKeyWords($outputlangs->convToOutputCharset($object->ref) . ' ' . $outputlangs->transnoentities('PdfTicketTitle') . ' ' . $outputlangs->convToOutputCharset($object->thirdparty->name));
 		$text = getDolGlobalString('TICKET_DRAFT_WATERMARK');
 		$substitutionarray = pdf_getSubstitutionArray($outputlangs, null, null);
 		complete_substitutions_array($substitutionarray, $outputlangs, null);
@@ -527,35 +233,10 @@ class doc_easydoc_ticket_html extends ModelePDFTicket
 		$mpdf->showWatermarkText = ($object->statut == Ticket::STATUS_WAITING && getDolGlobalString('TICKET_DRAFT_WATERMARK'));
 		$mpdf->watermark_font = 'DejaVuSansCondensed';
 		$mpdf->watermarkTextAlpha = 0.1;
-
 		$mpdf->SetDisplayMode('fullpage');
-
 		$mpdf->Bookmark($outputlangs->trans('PdfOrderTitle'));
 		$mpdf->WriteHTML($html);
 
-		$dir = $conf->ticket->multidir_output[$object->entity];
-		$objectref = dol_sanitizeFileName($object->ref);
-		if (!preg_match('/specimen/i', $objectref)) {
-			$dir .= "/" . $objectref;
-		}
-		$filename = str_replace('.twig', '', basename($srctemplatepath));
-		if (getDolGlobalInt('EASYDOC_ADD_TEMPLATE_SUFFIX_TO_FILENAME')) {
-			$file = $dir . "/" . $objectref . '_' . $filename . ".pdf";
-		} else {
-			$file = $dir . "/" . $objectref . ".pdf";
-		}
-
-		if (!file_exists($dir)) {
-			if (dol_mkdir($dir) < 0) {
-				$this->error = $langs->transnoentities("ErrorCanNotCreateDir", $dir);
-				return -1;
-			}
-		}
-
-		$mpdf->Output($file, \Mpdf\Output\Destination::FILE);
-
-		$this->result = ['fullpath' => $file];
-
-		return 1;
+		return $this->savePdf($mpdf, $object, $outputlangs, $conf->ticket->multidir_output[$object->entity], $srctemplatepath);
 	}
 }


### PR DESCRIPTION
Extract ~3000 lines of duplicated logic from all 9 PDF module classes into a single EasyDocHtmlTrait (class/EasyDocHtmlTrait.php). Each module now delegates shared tasks (Twig setup, logo/flag resolution, mysoc/thirdparty/contact/lines substitutions, PDF save + hook firing) to the trait, keeping only its module-specific logic.

Fixes: debug output unconditionally enabled in stock and ticket modules; afterPDFCreation hook missing in contract, expensereport, product, stock and ticket modules; undefined $substitutionarray in expedition free-text; dead code after return in contract module.